### PR TITLE
slugを自動生成して入力フォームを削除

### DIFF
--- a/backend/app/build.gradle.kts
+++ b/backend/app/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
     implementation(libs.flyway.core)
     implementation(libs.flyway.mysql)
 
+    // NanoID
+    implementation(libs.jnanoid)
+
     // Ktor Server
     implementation("io.ktor:ktor-server-core-jvm")
     implementation("io.ktor:ktor-server-netty-jvm")

--- a/backend/app/src/main/kotlin/my/backend/dto/BlogDto.kt
+++ b/backend/app/src/main/kotlin/my/backend/dto/BlogDto.kt
@@ -44,4 +44,21 @@ data class BlogResponseDto(
     val coverImage: String? = null,
     val tags: List<String>,
     val content: String,
-)
+) {
+    companion object {
+        fun fromRequestDto(
+            request: BlogRequestDto,
+            slug: String,
+        ): BlogResponseDto {
+            return BlogResponseDto(
+                slug = slug,
+                title = request.title,
+                date = request.date,
+                description = request.description,
+                coverImage = request.coverImage,
+                tags = request.tags,
+                content = request.content,
+            )
+        }
+    }
+}

--- a/backend/app/src/main/kotlin/my/backend/dto/BlogDto.kt
+++ b/backend/app/src/main/kotlin/my/backend/dto/BlogDto.kt
@@ -2,8 +2,41 @@ package my.backend.dto
 
 import kotlinx.serialization.Serializable
 
+/**
+ * ブログ記事作成・更新時のリクエストボディを表すDTO
+ * スラッグはサーバー側で生成またはURLパスから取得するため、このDTOには含まれない
+ *
+ * @property title 記事のタイトル
+ * @property date 記事の公開日
+ * @property description 記事の概要
+ * @property coverImage 記事のカバー画像のパスまたはURL（nullable）
+ * @property tags 記事に関連付けられたタグのリスト
+ * @property content 記事の本文
+ */
 @Serializable
-data class BlogDto(
+data class BlogRequestDto(
+    val title: String,
+    val date: String,
+    val description: String,
+    val coverImage: String? = null,
+    val tags: List<String>,
+    val content: String,
+)
+
+/**
+ * ブログ記事情報のレスポンスを表すDTO
+ * クライアントへの返却に必要な全ての情報を含む
+ *
+ * @property slug 記事を一意に識別するスラッグ（ID）
+ * @property title 記事のタイトル
+ * @property date 記事の公開日
+ * @property description 記事の概要
+ * @property coverImage 記事のカバー画像のパスまたはURL（nullable）
+ * @property tags 記事に関連付けられたタグのリスト
+ * @property content 記事の本文
+ */
+@Serializable
+data class BlogResponseDto(
     val slug: String,
     val title: String,
     val date: String,

--- a/backend/app/src/main/kotlin/my/backend/plugins/Security.kt
+++ b/backend/app/src/main/kotlin/my/backend/plugins/Security.kt
@@ -32,15 +32,11 @@ fun Application.configureSecurity() {
                 }
             }
             validate { credential ->
-                val userName = credential.payload.getClaim("user_name").asString()
-                if (userName.isNullOrEmpty()) return@validate null
-
-                credential.payload.getClaim("username").asString()?.let { userName ->
-                    if (userName.isNotEmpty()) {
-                        JWTPrincipal(credential.payload)
-                    } else {
-                        null
-                    }
+                val userName = credential.payload.getClaim("username").asString()
+                if (!userName.isNullOrEmpty()) {
+                    JWTPrincipal(credential.payload)
+                } else {
+                    null
                 }
             }
         }

--- a/backend/app/src/main/kotlin/my/backend/repository/BlogRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/BlogRepository.kt
@@ -4,6 +4,7 @@ import my.backend.db.schema.BlogTable
 import my.backend.db.schema.BlogTagsTable
 import my.backend.db.schema.TagTable
 import my.backend.dto.BlogDto
+import my.backend.util.SlugGenerator
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
@@ -73,9 +74,10 @@ class BlogRepositoryImpl : BlogRepository {
 
     override suspend fun create(blog: BlogDto): BlogDto =
         newSuspendedTransaction {
+            val newSlug = SlugGenerator.generate()
             val blogId =
                 BlogTable.insert {
-                    it[slug] = blog.slug
+                    it[slug] = newSlug
                     it[title] = blog.title
                     it[description] = blog.description
                     it[content] = blog.content
@@ -85,7 +87,7 @@ class BlogRepositoryImpl : BlogRepository {
 
             updateTags(blogId, blog.tags)
 
-            blog
+            blog.copy(slug = newSlug)
         }
 
     override suspend fun update(
@@ -108,7 +110,7 @@ class BlogRepositoryImpl : BlogRepository {
 
             updateTags(id, blog.tags)
 
-            blog
+            blog.copy(slug = slug)
         }
 
     override suspend fun delete(slug: String): Boolean =

--- a/backend/app/src/main/kotlin/my/backend/repository/BlogRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/BlogRepository.kt
@@ -88,15 +88,7 @@ class BlogRepositoryImpl : BlogRepository {
 
             updateTags(blogId, blog.tags)
 
-            BlogResponseDto(
-                slug = newSlug,
-                title = blog.title,
-                date = blog.date,
-                description = blog.description,
-                coverImage = blog.coverImage,
-                tags = blog.tags,
-                content = blog.content
-            )
+            BlogResponseDto.fromRequestDto(blog, newSlug)
         }
 
     override suspend fun update(
@@ -119,15 +111,7 @@ class BlogRepositoryImpl : BlogRepository {
 
             updateTags(id, blog.tags)
 
-            BlogResponseDto(
-                slug = slug,
-                title = blog.title,
-                date = blog.date,
-                description = blog.description,
-                coverImage = blog.coverImage,
-                tags = blog.tags,
-                content = blog.content
-            )
+            BlogResponseDto.fromRequestDto(blog, slug)
         }
 
     override suspend fun delete(slug: String): Boolean =

--- a/backend/app/src/main/kotlin/my/backend/routes/BlogRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/BlogRoutes.kt
@@ -6,7 +6,7 @@ import io.ktor.server.auth.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import my.backend.dto.BlogDto
+import my.backend.dto.BlogRequestDto
 import my.backend.service.BlogService
 
 fun Route.blogRoutes(blogService: BlogService) {
@@ -32,14 +32,14 @@ fun Route.blogRoutes(blogService: BlogService) {
 
         authenticate("auth-jwt") {
             post {
-                val blog = call.receive<BlogDto>()
+                val blog = call.receive<BlogRequestDto>()
                 val created = blogService.createBlog(blog)
                 call.respond(HttpStatusCode.Created, created)
             }
 
             put("/{slug}") {
                 val slug = call.parameters["slug"] ?: return@put call.respond(HttpStatusCode.BadRequest)
-                val blog = call.receive<BlogDto>()
+                val blog = call.receive<BlogRequestDto>()
                 val updated = blogService.updateBlog(slug, blog)
                 if (updated != null) {
                     call.respond(updated)

--- a/backend/app/src/main/kotlin/my/backend/service/BlogService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/BlogService.kt
@@ -1,6 +1,7 @@
 package my.backend.service
 
-import my.backend.dto.BlogDto
+import my.backend.dto.BlogRequestDto
+import my.backend.dto.BlogResponseDto
 import my.backend.repository.BlogRepository
 
 class BlogService(private val blogRepository: BlogRepository) {
@@ -8,22 +9,22 @@ class BlogService(private val blogRepository: BlogRepository) {
         limit: Int?,
         tags: List<String>?,
         keyword: String?,
-    ): List<BlogDto> {
+    ): List<BlogResponseDto> {
         return blogRepository.findAll(limit, tags, keyword)
     }
 
-    suspend fun getBlogBySlug(slug: String): BlogDto? {
+    suspend fun getBlogBySlug(slug: String): BlogResponseDto? {
         return blogRepository.findBySlug(slug)
     }
 
-    suspend fun createBlog(blog: BlogDto): BlogDto {
+    suspend fun createBlog(blog: BlogRequestDto): BlogResponseDto {
         return blogRepository.create(blog)
     }
 
     suspend fun updateBlog(
         slug: String,
-        blog: BlogDto,
-    ): BlogDto? {
+        blog: BlogRequestDto,
+    ): BlogResponseDto? {
         return blogRepository.update(slug, blog)
     }
 

--- a/backend/app/src/main/kotlin/my/backend/util/SlugGenerator.kt
+++ b/backend/app/src/main/kotlin/my/backend/util/SlugGenerator.kt
@@ -1,0 +1,17 @@
+package my.backend.util
+
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils
+
+object SlugGenerator {
+    /**
+     * URLセーフな一意のSlugを生成する。
+     * デフォルトで12文字のNanoIDを使用。
+     */
+    fun generate(): String {
+        return NanoIdUtils.randomNanoId(
+            NanoIdUtils.DEFAULT_NUMBER_GENERATOR,
+            NanoIdUtils.DEFAULT_ALPHABET,
+            12,
+        )
+    }
+}

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ hikaricp = "5.1.0"
 flyway = "11.19.0"
 h2 = "2.2.224"
 jbcrypt = "0.4"
+jnanoid = "2.0.0"
 
 [libraries]
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
@@ -33,6 +34,7 @@ exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", versio
 
 h2 = { module = "com.h2database:h2", version.ref = "h2" }
 jbcrypt = { module = "org.mindrot:jbcrypt", version.ref = "jbcrypt" }
+jnanoid = { module = "com.aventrix.jnanoid:jnanoid", version.ref = "jnanoid" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/frontend/src/app/admin/create/page.tsx
+++ b/frontend/src/app/admin/create/page.tsx
@@ -11,8 +11,6 @@ export default function CreateBlogPage() {
     form: {
       title,
       setTitle,
-      slug,
-      setSlug,
       description,
       setDescription,
       content,
@@ -57,18 +55,6 @@ export default function CreateBlogPage() {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            required
-          />
-        </div>
-        <div className="mb-4">
-          <label className="mb-2 block text-sm font-bold text-gray-700">
-            Slug
-          </label>
-          <input
-            className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-            type="text"
-            value={slug}
-            onChange={(e) => setSlug(e.target.value)}
             required
           />
         </div>

--- a/frontend/src/app/admin/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/edit/[slug]/page.tsx
@@ -13,8 +13,6 @@ export default function EditBlogPage() {
     form: {
       title,
       setTitle,
-      slug,
-      setSlug,
       description,
       setDescription,
       content,
@@ -59,18 +57,6 @@ export default function EditBlogPage() {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            required
-          />
-        </div>
-        <div className="mb-4">
-          <label className="mb-2 block text-sm font-bold text-gray-700">
-            Slug
-          </label>
-          <input
-            className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-            type="text"
-            value={slug}
-            onChange={(e) => setSlug(e.target.value)}
             required
           />
         </div>

--- a/frontend/src/app/hooks/admin/useAdminBlogCreate.ts
+++ b/frontend/src/app/hooks/admin/useAdminBlogCreate.ts
@@ -12,7 +12,6 @@ function toJaLongDateFromInput(date: string): string {
 
 export function useAdminBlogCreate() {
   const [title, setTitle] = useState("");
-  const [slug, setSlug] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
   const [tags, setTags] = useState("");
@@ -28,7 +27,6 @@ export function useAdminBlogCreate() {
 
     const payload: BlogUpsertInput = {
       title,
-      slug,
       description,
       content,
       tags: tags
@@ -47,14 +45,12 @@ export function useAdminBlogCreate() {
     } finally {
       setIsLoading(false);
     }
-  }, [title, slug, description, content, tags, coverImage, date]);
+  }, [title, description, content, tags, coverImage, date]);
 
   return {
     form: {
       title,
       setTitle,
-      slug,
-      setSlug,
       description,
       setDescription,
       content,

--- a/frontend/src/app/hooks/admin/useAdminBlogEdit.ts
+++ b/frontend/src/app/hooks/admin/useAdminBlogEdit.ts
@@ -20,7 +20,6 @@ function toJaLongDateFromInput(date: string): string {
 
 export function useAdminBlogEdit(originalSlug: string | undefined) {
   const [title, setTitle] = useState("");
-  const [slug, setSlug] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
   const [tags, setTags] = useState("");
@@ -41,7 +40,6 @@ export function useAdminBlogEdit(originalSlug: string | undefined) {
         const data: Blog = await adminBlogRepository.get(originalSlug);
         if (cancelled) return;
         setTitle(data.title);
-        setSlug(data.slug);
         setDescription(data.description);
         setContent(data.content);
         setTags((data.tags || []).join(", "));
@@ -67,7 +65,6 @@ export function useAdminBlogEdit(originalSlug: string | undefined) {
   const buildPayload = useCallback((): BlogUpsertInput => {
     return {
       title,
-      slug,
       description,
       content,
       tags: tags
@@ -77,7 +74,7 @@ export function useAdminBlogEdit(originalSlug: string | undefined) {
       coverImage,
       date: toJaLongDateFromInput(date),
     };
-  }, [title, slug, description, content, tags, coverImage, date]);
+  }, [title, description, content, tags, coverImage, date]);
 
   const submitUpdate = useCallback(async () => {
     if (!originalSlug) {
@@ -99,8 +96,6 @@ export function useAdminBlogEdit(originalSlug: string | undefined) {
     form: {
       title,
       setTitle,
-      slug,
-      setSlug,
       description,
       setDescription,
       content,
@@ -112,12 +107,7 @@ export function useAdminBlogEdit(originalSlug: string | undefined) {
       date,
       setDate,
     },
-    state: {
-      isLoading,
-      error,
-    },
-    actions: {
-      submitUpdate,
-    },
+    state: { isLoading, error },
+    actions: { submitUpdate },
   };
 }

--- a/frontend/src/app/types/blog.ts
+++ b/frontend/src/app/types/blog.ts
@@ -17,7 +17,6 @@ export type AdminBlogListItem = Pick<
 
 export type BlogUpsertInput = {
   title: string;
-  slug: string;
   date: string;
   description: string;
   content: string;


### PR DESCRIPTION
## 変更内容
- slug を NanoId で自動生成するように変更
- 認証通らない問題を直した

- [x] ⚠️ 認証が通らず動作検証ができていないため、別ブランチにて実装。マージ前に必ず別端末から検証が必要
  - 認証の修正が重い場合はこのブランチから fix ブランチを切ること

## 該当するissue

<!-- もしあれば -->

- close #