### PR TITLE
docker-composeのサーバーの環境変数の指定漏れ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - ADMIN_USERNAME=${ADMIN_USERNAME}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - KTOR_ENV=${KTOR_ENV}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## 変更内容
- `authRoute` で cookie に指定していた KTOR_ENV が docker-compose に指定が漏れていた

## 該当するissue

<!-- もしあれば -->

- close #