### PR TITLE
[Backend] ポートフォリオのテーブル定義とAPI実装

### DIFF
--- a/backend/app/build.gradle.kts
+++ b/backend/app/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
     // BCrypt
     implementation(libs.jbcrypt)
 
+    // HTML Sanitization
+    implementation(libs.jsoup)
+
     // Testing
     testImplementation(libs.h2)
     testImplementation("io.ktor:ktor-server-test-host")

--- a/backend/app/src/main/kotlin/my/backend/Application.kt
+++ b/backend/app/src/main/kotlin/my/backend/Application.kt
@@ -18,6 +18,7 @@ fun Application.module() {
     configureSerialization()
     configureHTTP()
     configureSecurity()
+    configureCsrfProtection()
     configureValidation()
     configureStatusPages()
     configureRouting()

--- a/backend/app/src/main/kotlin/my/backend/db/schema/PortfolioTable.kt
+++ b/backend/app/src/main/kotlin/my/backend/db/schema/PortfolioTable.kt
@@ -1,0 +1,30 @@
+package my.backend.db.schema
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.javatime.datetime
+
+object PortfolioTable : Table("portfolios") {
+    val id = integer("id").autoIncrement()
+    val slug = varchar("slug", 255).uniqueIndex()
+    val title = varchar("title", 255)
+    val description = text("description")
+    val content = text("content")
+    val coverImage = varchar("cover_image", 255).nullable()
+    val date = datetime("date")
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object PortfolioTagNameTable : Table("portfolio_tag_names") {
+    val id = integer("id").autoIncrement()
+    val name = varchar("name", 50).uniqueIndex()
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object PortfolioTagsTable : Table("portfolio_tags") {
+    val portfolioId = reference("portfolio_id", PortfolioTable.id)
+    val tagId = reference("tag_id", PortfolioTagNameTable.id)
+
+    override val primaryKey = PrimaryKey(portfolioId, tagId)
+}

--- a/backend/app/src/main/kotlin/my/backend/db/schema/PortfolioTable.kt
+++ b/backend/app/src/main/kotlin/my/backend/db/schema/PortfolioTable.kt
@@ -14,17 +14,3 @@ object PortfolioTable : Table("portfolios") {
 
     override val primaryKey = PrimaryKey(id)
 }
-
-object PortfolioTagNameTable : Table("portfolio_tag_names") {
-    val id = integer("id").autoIncrement()
-    val name = varchar("name", 50).uniqueIndex()
-
-    override val primaryKey = PrimaryKey(id)
-}
-
-object PortfolioTagsTable : Table("portfolio_tags") {
-    val portfolioId = reference("portfolio_id", PortfolioTable.id)
-    val tagId = reference("tag_id", PortfolioTagNameTable.id)
-
-    override val primaryKey = PrimaryKey(portfolioId, tagId)
-}

--- a/backend/app/src/main/kotlin/my/backend/di/AppModule.kt
+++ b/backend/app/src/main/kotlin/my/backend/di/AppModule.kt
@@ -12,6 +12,8 @@ import kotlinx.serialization.json.Json
 import my.backend.db.DatabaseFactory
 import my.backend.repository.BlogRepository
 import my.backend.repository.BlogRepositoryImpl
+import my.backend.repository.PortfolioRepository
+import my.backend.repository.PortfolioRepositoryImpl
 import my.backend.repository.UserRepository
 import my.backend.repository.UserRepositoryImpl
 import my.backend.service.AuthService
@@ -57,10 +59,11 @@ fun appModule(config: ApplicationConfig) =
         // Repositories
         single<BlogRepository> { BlogRepositoryImpl() }
         single<UserRepository> { UserRepositoryImpl() }
+        single<PortfolioRepository> { PortfolioRepositoryImpl() }
 
         // Services
         single { BlogService(get()) }
         single { ContactService(get(), get(), get()) }
-        single { PortfolioService() }
+        single { PortfolioService(get()) }
         single { AuthService(get(), get()) }
     }

--- a/backend/app/src/main/kotlin/my/backend/dto/PortfolioDto.kt
+++ b/backend/app/src/main/kotlin/my/backend/dto/PortfolioDto.kt
@@ -12,7 +12,6 @@ data class PortfolioRequestDto(
     val date: String,
     val description: String,
     val coverImage: String? = null,
-    val tags: List<String>,
     val content: String,
 )
 
@@ -27,7 +26,6 @@ data class PortfolioResponseDto(
     val date: String,
     val description: String,
     val coverImage: String? = null,
-    val tags: List<String>,
     val content: String,
 ) {
     companion object {
@@ -41,7 +39,6 @@ data class PortfolioResponseDto(
                 date = request.date,
                 description = request.description,
                 coverImage = request.coverImage,
-                tags = request.tags,
                 content = request.content,
             )
         }

--- a/backend/app/src/main/kotlin/my/backend/dto/PortfolioDto.kt
+++ b/backend/app/src/main/kotlin/my/backend/dto/PortfolioDto.kt
@@ -2,9 +2,12 @@ package my.backend.dto
 
 import kotlinx.serialization.Serializable
 
+/**
+ * ポートフォリオ作成・更新時のリクエストボディを表すDTO
+ * スラッグはサーバー側で生成またはURLパスから取得するため、このDTOには含まれない
+ */
 @Serializable
-data class PortfolioDto(
-    val slug: String,
+data class PortfolioRequestDto(
     val title: String,
     val date: String,
     val description: String,
@@ -12,3 +15,35 @@ data class PortfolioDto(
     val tags: List<String>,
     val content: String,
 )
+
+/**
+ * ポートフォリオ情報のレスポンスを表すDTO
+ * クライアントへの返却に必要な全ての情報を含む
+ */
+@Serializable
+data class PortfolioResponseDto(
+    val slug: String,
+    val title: String,
+    val date: String,
+    val description: String,
+    val coverImage: String? = null,
+    val tags: List<String>,
+    val content: String,
+) {
+    companion object {
+        fun fromRequestDto(
+            request: PortfolioRequestDto,
+            slug: String,
+        ): PortfolioResponseDto {
+            return PortfolioResponseDto(
+                slug = slug,
+                title = request.title,
+                date = request.date,
+                description = request.description,
+                coverImage = request.coverImage,
+                tags = request.tags,
+                content = request.content,
+            )
+        }
+    }
+}

--- a/backend/app/src/main/kotlin/my/backend/plugins/CsrfProtection.kt
+++ b/backend/app/src/main/kotlin/my/backend/plugins/CsrfProtection.kt
@@ -1,0 +1,35 @@
+package my.backend.plugins
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import my.backend.dto.ApiResponse
+
+private val MUTATING_METHODS = setOf(HttpMethod.Post, HttpMethod.Put, HttpMethod.Delete, HttpMethod.Patch)
+
+private val CsrfProtection =
+    createApplicationPlugin("CsrfProtection") {
+        val configValue =
+            application.environment.config
+                .property("app.cors.allowed-origins")
+                .getString()
+
+        val allowedOrigins = configValue.split(",").map { it.trim().trimEnd('/') }
+
+        onCall { call ->
+            if (call.request.httpMethod in MUTATING_METHODS) {
+                val origin = call.request.headers[HttpHeaders.Origin]
+                if (origin == null || origin.trimEnd('/') !in allowedOrigins) {
+                    call.respond(
+                        HttpStatusCode.Forbidden,
+                        ApiResponse(error = "不正なオリジンからのリクエストは許可されていません。"),
+                    )
+                }
+            }
+        }
+    }
+
+fun Application.configureCsrfProtection() {
+    install(CsrfProtection)
+}

--- a/backend/app/src/main/kotlin/my/backend/plugins/HTTP.kt
+++ b/backend/app/src/main/kotlin/my/backend/plugins/HTTP.kt
@@ -7,8 +7,9 @@ import java.net.URI
 
 fun Application.configureHTTP() {
     val allowedOrigins =
-        environment.config.propertyOrNull("app.cors.allowed-origins")?.getString()
-            ?: "http://localhost:3000"
+        environment.config
+            .property("app.cors.allowed-origins")
+            .getString()
 
     install(CORS) {
         allowMethod(HttpMethod.Options)

--- a/backend/app/src/main/kotlin/my/backend/plugins/StatusPages.kt
+++ b/backend/app/src/main/kotlin/my/backend/plugins/StatusPages.kt
@@ -43,6 +43,15 @@ fun Application.configureStatusPages() {
             )
         }
 
+        // 不正な日付フォーマットエラー
+        exception<IllegalArgumentException> { call, cause ->
+            logger.warn("Invalid argument: ${cause.message}")
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ApiResponse(error = cause.message ?: "不正なリクエストです。"),
+            )
+        }
+
         // Turnstile認証エラー
         exception<TurnstileVerificationException> { call, cause ->
             logger.error("Turnstile verification failed:", cause)

--- a/backend/app/src/main/kotlin/my/backend/repository/BlogRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/BlogRepository.kt
@@ -6,13 +6,11 @@ import my.backend.db.schema.TagTable
 import my.backend.dto.BlogRequestDto
 import my.backend.dto.BlogResponseDto
 import my.backend.util.SlugGenerator
+import my.backend.util.formatLocalDateTime
+import my.backend.util.parseDateToLocalDateTime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 interface BlogRepository {
     suspend fun findAll(
@@ -34,8 +32,6 @@ interface BlogRepository {
 }
 
 class BlogRepositoryImpl : BlogRepository {
-    private val dateFormatter = DateTimeFormatter.ofPattern("yyyy年M月d日", Locale.JAPAN)
-
     override suspend fun findAll(
         limit: Int?,
         tags: List<String>?,
@@ -96,6 +92,7 @@ class BlogRepositoryImpl : BlogRepository {
     override suspend fun create(blog: BlogRequestDto): BlogResponseDto =
         newSuspendedTransaction {
             val newSlug = SlugGenerator.generate()
+            val parsedDate = parseDateToLocalDateTime(blog.date)
             val blogId =
                 BlogTable.insert {
                     it[slug] = newSlug
@@ -103,12 +100,20 @@ class BlogRepositoryImpl : BlogRepository {
                     it[description] = blog.description
                     it[content] = blog.content
                     it[coverImage] = blog.coverImage
-                    it[date] = parseDate(blog.date)
+                    it[date] = parsedDate
                 } get BlogTable.id
 
             updateTags(blogId, blog.tags)
 
-            BlogResponseDto.fromRequestDto(blog, newSlug)
+            BlogResponseDto(
+                slug = newSlug,
+                title = blog.title,
+                date = formatLocalDateTime(parsedDate),
+                description = blog.description,
+                coverImage = blog.coverImage,
+                tags = blog.tags,
+                content = blog.content,
+            )
         }
 
     override suspend fun update(
@@ -126,7 +131,7 @@ class BlogRepositoryImpl : BlogRepository {
                 it[description] = blog.description
                 it[content] = blog.content
                 it[coverImage] = blog.coverImage
-                it[date] = parseDate(blog.date)
+                it[date] = parseDateToLocalDateTime(blog.date)
             }
 
             updateTags(id, blog.tags)
@@ -153,7 +158,7 @@ class BlogRepositoryImpl : BlogRepository {
         return BlogResponseDto(
             slug = row[BlogTable.slug],
             title = row[BlogTable.title],
-            date = row[BlogTable.date].format(dateFormatter),
+            date = formatLocalDateTime(row[BlogTable.date]),
             description = row[BlogTable.description],
             coverImage = row[BlogTable.coverImage],
             tags = tags,
@@ -178,14 +183,6 @@ class BlogRepositoryImpl : BlogRepository {
         BlogTagsTable.batchInsert(tagIds) { tagId ->
             this[BlogTagsTable.blogId] = blogId
             this[BlogTagsTable.tagId] = tagId
-        }
-    }
-
-    private fun parseDate(dateString: String): LocalDateTime {
-        return try {
-            LocalDate.parse(dateString, dateFormatter).atStartOfDay()
-        } catch (e: Exception) {
-            LocalDateTime.now()
         }
     }
 

--- a/backend/app/src/main/kotlin/my/backend/repository/BlogRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/BlogRepository.kt
@@ -5,9 +5,8 @@ import my.backend.db.schema.BlogTagsTable
 import my.backend.db.schema.TagTable
 import my.backend.dto.BlogRequestDto
 import my.backend.dto.BlogResponseDto
+import my.backend.util.DateParser
 import my.backend.util.SlugGenerator
-import my.backend.util.formatLocalDateTime
-import my.backend.util.parseDateToLocalDateTime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
@@ -92,7 +91,6 @@ class BlogRepositoryImpl : BlogRepository {
     override suspend fun create(blog: BlogRequestDto): BlogResponseDto =
         newSuspendedTransaction {
             val newSlug = SlugGenerator.generate()
-            val parsedDate = parseDateToLocalDateTime(blog.date)
             val blogId =
                 BlogTable.insert {
                     it[slug] = newSlug
@@ -100,20 +98,12 @@ class BlogRepositoryImpl : BlogRepository {
                     it[description] = blog.description
                     it[content] = blog.content
                     it[coverImage] = blog.coverImage
-                    it[date] = parsedDate
+                    it[date] = DateParser.parseDateToLocalDateTime(blog.date)
                 } get BlogTable.id
 
             updateTags(blogId, blog.tags)
 
-            BlogResponseDto(
-                slug = newSlug,
-                title = blog.title,
-                date = formatLocalDateTime(parsedDate),
-                description = blog.description,
-                coverImage = blog.coverImage,
-                tags = blog.tags,
-                content = blog.content,
-            )
+            BlogResponseDto.fromRequestDto(blog, newSlug)
         }
 
     override suspend fun update(
@@ -131,7 +121,7 @@ class BlogRepositoryImpl : BlogRepository {
                 it[description] = blog.description
                 it[content] = blog.content
                 it[coverImage] = blog.coverImage
-                it[date] = parseDateToLocalDateTime(blog.date)
+                it[date] = DateParser.parseDateToLocalDateTime(blog.date)
             }
 
             updateTags(id, blog.tags)
@@ -158,7 +148,7 @@ class BlogRepositoryImpl : BlogRepository {
         return BlogResponseDto(
             slug = row[BlogTable.slug],
             title = row[BlogTable.title],
-            date = formatLocalDateTime(row[BlogTable.date]),
+            date = row[BlogTable.date].format(DateParser.dateFormatter),
             description = row[BlogTable.description],
             coverImage = row[BlogTable.coverImage],
             tags = tags,

--- a/backend/app/src/main/kotlin/my/backend/repository/PortfolioRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/PortfolioRepository.kt
@@ -4,13 +4,11 @@ import my.backend.db.schema.PortfolioTable
 import my.backend.dto.PortfolioRequestDto
 import my.backend.dto.PortfolioResponseDto
 import my.backend.util.SlugGenerator
+import my.backend.util.formatLocalDateTime
+import my.backend.util.parseDateToLocalDateTime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 interface PortfolioRepository {
     suspend fun findAll(limit: Int? = null): List<PortfolioResponseDto>
@@ -28,8 +26,6 @@ interface PortfolioRepository {
 }
 
 class PortfolioRepositoryImpl : PortfolioRepository {
-    private val dateFormatter = DateTimeFormatter.ofPattern("yyyy年M月d日", Locale.JAPAN)
-
     override suspend fun findAll(limit: Int?): List<PortfolioResponseDto> =
         newSuspendedTransaction {
             val query =
@@ -50,16 +46,24 @@ class PortfolioRepositoryImpl : PortfolioRepository {
     override suspend fun create(portfolio: PortfolioRequestDto): PortfolioResponseDto =
         newSuspendedTransaction {
             val newSlug = SlugGenerator.generate()
+            val parsedDate = parseDateToLocalDateTime(portfolio.date)
             PortfolioTable.insert {
                 it[slug] = newSlug
                 it[title] = portfolio.title
                 it[description] = portfolio.description
                 it[content] = portfolio.content
                 it[coverImage] = portfolio.coverImage
-                it[date] = parseDate(portfolio.date)
+                it[date] = parsedDate
             }
 
-            PortfolioResponseDto.fromRequestDto(portfolio, newSlug)
+            PortfolioResponseDto(
+                slug = newSlug,
+                title = portfolio.title,
+                date = formatLocalDateTime(parsedDate),
+                description = portfolio.description,
+                coverImage = portfolio.coverImage,
+                content = portfolio.content,
+            )
         }
 
     override suspend fun update(
@@ -67,20 +71,28 @@ class PortfolioRepositoryImpl : PortfolioRepository {
         portfolio: PortfolioRequestDto,
     ): PortfolioResponseDto? =
         newSuspendedTransaction {
-            val existing =
-                PortfolioTable.selectAll().where { PortfolioTable.slug eq slug }
-                    .singleOrNull() ?: return@newSuspendedTransaction null
-            val id = existing[PortfolioTable.id]
+            val parsedDate = parseDateToLocalDateTime(portfolio.date)
+            val updatedRows =
+                PortfolioTable.update({ PortfolioTable.slug eq slug }) {
+                    it[title] = portfolio.title
+                    it[description] = portfolio.description
+                    it[content] = portfolio.content
+                    it[coverImage] = portfolio.coverImage
+                    it[date] = parsedDate
+                }
 
-            PortfolioTable.update({ PortfolioTable.id eq id }) {
-                it[title] = portfolio.title
-                it[description] = portfolio.description
-                it[content] = portfolio.content
-                it[coverImage] = portfolio.coverImage
-                it[date] = parseDate(portfolio.date)
+            if (updatedRows > 0) {
+                PortfolioResponseDto(
+                    slug = slug,
+                    title = portfolio.title,
+                    date = formatLocalDateTime(parsedDate),
+                    description = portfolio.description,
+                    coverImage = portfolio.coverImage,
+                    content = portfolio.content,
+                )
+            } else {
+                null
             }
-
-            PortfolioResponseDto.fromRequestDto(portfolio, slug)
         }
 
     override suspend fun delete(slug: String): Boolean =
@@ -92,18 +104,10 @@ class PortfolioRepositoryImpl : PortfolioRepository {
         return PortfolioResponseDto(
             slug = row[PortfolioTable.slug],
             title = row[PortfolioTable.title],
-            date = row[PortfolioTable.date].format(dateFormatter),
+            date = formatLocalDateTime(row[PortfolioTable.date]),
             description = row[PortfolioTable.description],
             coverImage = row[PortfolioTable.coverImage],
             content = row[PortfolioTable.content],
         )
-    }
-
-    private fun parseDate(dateString: String): LocalDateTime {
-        return try {
-            LocalDate.parse(dateString, dateFormatter).atStartOfDay()
-        } catch (e: Exception) {
-            LocalDateTime.now()
-        }
     }
 }

--- a/backend/app/src/main/kotlin/my/backend/repository/PortfolioRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/PortfolioRepository.kt
@@ -3,9 +3,8 @@ package my.backend.repository
 import my.backend.db.schema.PortfolioTable
 import my.backend.dto.PortfolioRequestDto
 import my.backend.dto.PortfolioResponseDto
+import my.backend.util.DateParser
 import my.backend.util.SlugGenerator
-import my.backend.util.formatLocalDateTime
-import my.backend.util.parseDateToLocalDateTime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
@@ -46,24 +45,16 @@ class PortfolioRepositoryImpl : PortfolioRepository {
     override suspend fun create(portfolio: PortfolioRequestDto): PortfolioResponseDto =
         newSuspendedTransaction {
             val newSlug = SlugGenerator.generate()
-            val parsedDate = parseDateToLocalDateTime(portfolio.date)
             PortfolioTable.insert {
                 it[slug] = newSlug
                 it[title] = portfolio.title
                 it[description] = portfolio.description
                 it[content] = portfolio.content
                 it[coverImage] = portfolio.coverImage
-                it[date] = parsedDate
+                it[date] = DateParser.parseDateToLocalDateTime(portfolio.date)
             }
 
-            PortfolioResponseDto(
-                slug = newSlug,
-                title = portfolio.title,
-                date = formatLocalDateTime(parsedDate),
-                description = portfolio.description,
-                coverImage = portfolio.coverImage,
-                content = portfolio.content,
-            )
+            PortfolioResponseDto.fromRequestDto(portfolio, newSlug)
         }
 
     override suspend fun update(
@@ -71,25 +62,17 @@ class PortfolioRepositoryImpl : PortfolioRepository {
         portfolio: PortfolioRequestDto,
     ): PortfolioResponseDto? =
         newSuspendedTransaction {
-            val parsedDate = parseDateToLocalDateTime(portfolio.date)
             val updatedRows =
                 PortfolioTable.update({ PortfolioTable.slug eq slug }) {
                     it[title] = portfolio.title
                     it[description] = portfolio.description
                     it[content] = portfolio.content
                     it[coverImage] = portfolio.coverImage
-                    it[date] = parsedDate
+                    it[date] = DateParser.parseDateToLocalDateTime(portfolio.date)
                 }
 
             if (updatedRows > 0) {
-                PortfolioResponseDto(
-                    slug = slug,
-                    title = portfolio.title,
-                    date = formatLocalDateTime(parsedDate),
-                    description = portfolio.description,
-                    coverImage = portfolio.coverImage,
-                    content = portfolio.content,
-                )
+                PortfolioResponseDto.fromRequestDto(portfolio, slug)
             } else {
                 null
             }
@@ -104,7 +87,7 @@ class PortfolioRepositoryImpl : PortfolioRepository {
         return PortfolioResponseDto(
             slug = row[PortfolioTable.slug],
             title = row[PortfolioTable.title],
-            date = formatLocalDateTime(row[PortfolioTable.date]),
+            date = row[PortfolioTable.date].format(DateParser.dateFormatter),
             description = row[PortfolioTable.description],
             coverImage = row[PortfolioTable.coverImage],
             content = row[PortfolioTable.content],

--- a/backend/app/src/main/kotlin/my/backend/repository/PortfolioRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/PortfolioRepository.kt
@@ -1,8 +1,6 @@
 package my.backend.repository
 
 import my.backend.db.schema.PortfolioTable
-import my.backend.db.schema.PortfolioTagNameTable
-import my.backend.db.schema.PortfolioTagsTable
 import my.backend.dto.PortfolioRequestDto
 import my.backend.dto.PortfolioResponseDto
 import my.backend.util.SlugGenerator
@@ -15,11 +13,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 interface PortfolioRepository {
-    suspend fun findAll(
-        limit: Int? = null,
-        tags: List<String>? = null,
-        keyword: String? = null,
-    ): List<PortfolioResponseDto>
+    suspend fun findAll(limit: Int? = null): List<PortfolioResponseDto>
 
     suspend fun findBySlug(slug: String): PortfolioResponseDto?
 
@@ -36,78 +30,34 @@ interface PortfolioRepository {
 class PortfolioRepositoryImpl : PortfolioRepository {
     private val dateFormatter = DateTimeFormatter.ofPattern("yyyy年M月d日", Locale.JAPAN)
 
-    override suspend fun findAll(
-        limit: Int?,
-        tags: List<String>?,
-        keyword: String?,
-    ): List<PortfolioResponseDto> =
+    override suspend fun findAll(limit: Int?): List<PortfolioResponseDto> =
         newSuspendedTransaction {
-            val query = PortfolioTable.selectAll()
-
-            if (!tags.isNullOrEmpty()) {
-                val portfolioIdsWithTags =
-                    (PortfolioTagsTable innerJoin PortfolioTagNameTable)
-                        .selectAll().where { PortfolioTagNameTable.name inList tags }
-                        .map { it[PortfolioTagsTable.portfolioId] }
-
-                query.andWhere { PortfolioTable.id inList portfolioIdsWithTags }
-            }
-
-            if (!keyword.isNullOrBlank()) {
-                val escapedKeyword = escapeLikePattern(keyword)
-                query.andWhere {
-                    (PortfolioTable.title like "%$escapedKeyword%") or
-                        (PortfolioTable.description like "%$escapedKeyword%")
-                }
-            }
-
-            query.orderBy(PortfolioTable.date to SortOrder.DESC)
+            val query =
+                PortfolioTable.selectAll()
+                    .orderBy(PortfolioTable.date to SortOrder.DESC)
 
             val resultQuery = if (limit != null) query.limit(limit) else query
-            val resultRows = resultQuery.toList()
-
-            if (resultRows.isEmpty()) return@newSuspendedTransaction emptyList()
-
-            val portfolioIds = resultRows.map { it[PortfolioTable.id] }
-            val tagsMap =
-                (PortfolioTagsTable innerJoin PortfolioTagNameTable)
-                    .selectAll()
-                    .where { PortfolioTagsTable.portfolioId inList portfolioIds }
-                    .groupBy { it[PortfolioTagsTable.portfolioId] }
-                    .mapValues { entry -> entry.value.map { it[PortfolioTagNameTable.name] } }
-
-            resultRows.map { toPortfolioResponseDto(it, tagsMap[it[PortfolioTable.id]] ?: emptyList()) }
+            resultQuery.map { toPortfolioResponseDto(it) }
         }
 
     override suspend fun findBySlug(slug: String): PortfolioResponseDto? =
         newSuspendedTransaction {
-            val row =
-                PortfolioTable.selectAll().where { PortfolioTable.slug eq slug }
-                    .singleOrNull() ?: return@newSuspendedTransaction null
-
-            val portfolioId = row[PortfolioTable.id]
-            val tags =
-                (PortfolioTagsTable innerJoin PortfolioTagNameTable)
-                    .selectAll().where { PortfolioTagsTable.portfolioId eq portfolioId }
-                    .map { it[PortfolioTagNameTable.name] }
-
-            toPortfolioResponseDto(row, tags)
+            PortfolioTable.selectAll().where { PortfolioTable.slug eq slug }
+                .singleOrNull()
+                ?.let { toPortfolioResponseDto(it) }
         }
 
     override suspend fun create(portfolio: PortfolioRequestDto): PortfolioResponseDto =
         newSuspendedTransaction {
             val newSlug = SlugGenerator.generate()
-            val portfolioId =
-                PortfolioTable.insert {
-                    it[slug] = newSlug
-                    it[title] = portfolio.title
-                    it[description] = portfolio.description
-                    it[content] = portfolio.content
-                    it[coverImage] = portfolio.coverImage
-                    it[date] = parseDate(portfolio.date)
-                } get PortfolioTable.id
-
-            updateTags(portfolioId, portfolio.tags)
+            PortfolioTable.insert {
+                it[slug] = newSlug
+                it[title] = portfolio.title
+                it[description] = portfolio.description
+                it[content] = portfolio.content
+                it[coverImage] = portfolio.coverImage
+                it[date] = parseDate(portfolio.date)
+            }
 
             PortfolioResponseDto.fromRequestDto(portfolio, newSlug)
         }
@@ -130,59 +80,23 @@ class PortfolioRepositoryImpl : PortfolioRepository {
                 it[date] = parseDate(portfolio.date)
             }
 
-            updateTags(id, portfolio.tags)
-
             PortfolioResponseDto.fromRequestDto(portfolio, slug)
         }
 
     override suspend fun delete(slug: String): Boolean =
         newSuspendedTransaction {
-            val existing =
-                PortfolioTable.selectAll().where { PortfolioTable.slug eq slug }
-                    .singleOrNull() ?: return@newSuspendedTransaction false
-            val id = existing[PortfolioTable.id]
-
-            PortfolioTagsTable.deleteWhere { portfolioId eq id }
-
-            PortfolioTable.deleteWhere { PortfolioTable.id eq id } > 0
+            PortfolioTable.deleteWhere { PortfolioTable.slug eq slug } > 0
         }
 
-    private fun toPortfolioResponseDto(
-        row: ResultRow,
-        tags: List<String>,
-    ): PortfolioResponseDto {
+    private fun toPortfolioResponseDto(row: ResultRow): PortfolioResponseDto {
         return PortfolioResponseDto(
             slug = row[PortfolioTable.slug],
             title = row[PortfolioTable.title],
             date = row[PortfolioTable.date].format(dateFormatter),
             description = row[PortfolioTable.description],
             coverImage = row[PortfolioTable.coverImage],
-            tags = tags,
             content = row[PortfolioTable.content],
         )
-    }
-
-    private fun updateTags(
-        portfolioId: Int,
-        tags: List<String>,
-    ) {
-        PortfolioTagsTable.deleteWhere { PortfolioTagsTable.portfolioId eq portfolioId }
-
-        if (tags.isEmpty()) return
-
-        PortfolioTagNameTable.batchInsert(tags, ignore = true) { tagName ->
-            this[PortfolioTagNameTable.name] = tagName
-        }
-
-        val tagIds =
-            PortfolioTagNameTable.selectAll()
-                .where { PortfolioTagNameTable.name inList tags }
-                .map { it[PortfolioTagNameTable.id] }
-
-        PortfolioTagsTable.batchInsert(tagIds) { tagId ->
-            this[PortfolioTagsTable.portfolioId] = portfolioId
-            this[PortfolioTagsTable.tagId] = tagId
-        }
     }
 
     private fun parseDate(dateString: String): LocalDateTime {
@@ -191,12 +105,5 @@ class PortfolioRepositoryImpl : PortfolioRepository {
         } catch (e: Exception) {
             LocalDateTime.now()
         }
-    }
-
-    private fun escapeLikePattern(keyword: String): String {
-        return keyword
-            .replace("\\", "\\\\")
-            .replace("%", "\\%")
-            .replace("_", "\\_")
     }
 }

--- a/backend/app/src/main/kotlin/my/backend/repository/PortfolioRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/PortfolioRepository.kt
@@ -1,0 +1,202 @@
+package my.backend.repository
+
+import my.backend.db.schema.PortfolioTable
+import my.backend.db.schema.PortfolioTagNameTable
+import my.backend.db.schema.PortfolioTagsTable
+import my.backend.dto.PortfolioRequestDto
+import my.backend.dto.PortfolioResponseDto
+import my.backend.util.SlugGenerator
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+interface PortfolioRepository {
+    suspend fun findAll(
+        limit: Int? = null,
+        tags: List<String>? = null,
+        keyword: String? = null,
+    ): List<PortfolioResponseDto>
+
+    suspend fun findBySlug(slug: String): PortfolioResponseDto?
+
+    suspend fun create(portfolio: PortfolioRequestDto): PortfolioResponseDto
+
+    suspend fun update(
+        slug: String,
+        portfolio: PortfolioRequestDto,
+    ): PortfolioResponseDto?
+
+    suspend fun delete(slug: String): Boolean
+}
+
+class PortfolioRepositoryImpl : PortfolioRepository {
+    private val dateFormatter = DateTimeFormatter.ofPattern("yyyy年M月d日", Locale.JAPAN)
+
+    override suspend fun findAll(
+        limit: Int?,
+        tags: List<String>?,
+        keyword: String?,
+    ): List<PortfolioResponseDto> =
+        newSuspendedTransaction {
+            val query = PortfolioTable.selectAll()
+
+            if (!tags.isNullOrEmpty()) {
+                val portfolioIdsWithTags =
+                    (PortfolioTagsTable innerJoin PortfolioTagNameTable)
+                        .selectAll().where { PortfolioTagNameTable.name inList tags }
+                        .map { it[PortfolioTagsTable.portfolioId] }
+
+                query.andWhere { PortfolioTable.id inList portfolioIdsWithTags }
+            }
+
+            if (!keyword.isNullOrBlank()) {
+                val escapedKeyword = escapeLikePattern(keyword)
+                query.andWhere {
+                    (PortfolioTable.title like "%$escapedKeyword%") or
+                        (PortfolioTable.description like "%$escapedKeyword%")
+                }
+            }
+
+            query.orderBy(PortfolioTable.date to SortOrder.DESC)
+
+            val resultQuery = if (limit != null) query.limit(limit) else query
+            val resultRows = resultQuery.toList()
+
+            if (resultRows.isEmpty()) return@newSuspendedTransaction emptyList()
+
+            val portfolioIds = resultRows.map { it[PortfolioTable.id] }
+            val tagsMap =
+                (PortfolioTagsTable innerJoin PortfolioTagNameTable)
+                    .selectAll()
+                    .where { PortfolioTagsTable.portfolioId inList portfolioIds }
+                    .groupBy { it[PortfolioTagsTable.portfolioId] }
+                    .mapValues { entry -> entry.value.map { it[PortfolioTagNameTable.name] } }
+
+            resultRows.map { toPortfolioResponseDto(it, tagsMap[it[PortfolioTable.id]] ?: emptyList()) }
+        }
+
+    override suspend fun findBySlug(slug: String): PortfolioResponseDto? =
+        newSuspendedTransaction {
+            val row =
+                PortfolioTable.selectAll().where { PortfolioTable.slug eq slug }
+                    .singleOrNull() ?: return@newSuspendedTransaction null
+
+            val portfolioId = row[PortfolioTable.id]
+            val tags =
+                (PortfolioTagsTable innerJoin PortfolioTagNameTable)
+                    .selectAll().where { PortfolioTagsTable.portfolioId eq portfolioId }
+                    .map { it[PortfolioTagNameTable.name] }
+
+            toPortfolioResponseDto(row, tags)
+        }
+
+    override suspend fun create(portfolio: PortfolioRequestDto): PortfolioResponseDto =
+        newSuspendedTransaction {
+            val newSlug = SlugGenerator.generate()
+            val portfolioId =
+                PortfolioTable.insert {
+                    it[slug] = newSlug
+                    it[title] = portfolio.title
+                    it[description] = portfolio.description
+                    it[content] = portfolio.content
+                    it[coverImage] = portfolio.coverImage
+                    it[date] = parseDate(portfolio.date)
+                } get PortfolioTable.id
+
+            updateTags(portfolioId, portfolio.tags)
+
+            PortfolioResponseDto.fromRequestDto(portfolio, newSlug)
+        }
+
+    override suspend fun update(
+        slug: String,
+        portfolio: PortfolioRequestDto,
+    ): PortfolioResponseDto? =
+        newSuspendedTransaction {
+            val existing =
+                PortfolioTable.selectAll().where { PortfolioTable.slug eq slug }
+                    .singleOrNull() ?: return@newSuspendedTransaction null
+            val id = existing[PortfolioTable.id]
+
+            PortfolioTable.update({ PortfolioTable.id eq id }) {
+                it[title] = portfolio.title
+                it[description] = portfolio.description
+                it[content] = portfolio.content
+                it[coverImage] = portfolio.coverImage
+                it[date] = parseDate(portfolio.date)
+            }
+
+            updateTags(id, portfolio.tags)
+
+            PortfolioResponseDto.fromRequestDto(portfolio, slug)
+        }
+
+    override suspend fun delete(slug: String): Boolean =
+        newSuspendedTransaction {
+            val existing =
+                PortfolioTable.selectAll().where { PortfolioTable.slug eq slug }
+                    .singleOrNull() ?: return@newSuspendedTransaction false
+            val id = existing[PortfolioTable.id]
+
+            PortfolioTagsTable.deleteWhere { portfolioId eq id }
+
+            PortfolioTable.deleteWhere { PortfolioTable.id eq id } > 0
+        }
+
+    private fun toPortfolioResponseDto(
+        row: ResultRow,
+        tags: List<String>,
+    ): PortfolioResponseDto {
+        return PortfolioResponseDto(
+            slug = row[PortfolioTable.slug],
+            title = row[PortfolioTable.title],
+            date = row[PortfolioTable.date].format(dateFormatter),
+            description = row[PortfolioTable.description],
+            coverImage = row[PortfolioTable.coverImage],
+            tags = tags,
+            content = row[PortfolioTable.content],
+        )
+    }
+
+    private fun updateTags(
+        portfolioId: Int,
+        tags: List<String>,
+    ) {
+        PortfolioTagsTable.deleteWhere { PortfolioTagsTable.portfolioId eq portfolioId }
+
+        if (tags.isEmpty()) return
+
+        PortfolioTagNameTable.batchInsert(tags, ignore = true) { tagName ->
+            this[PortfolioTagNameTable.name] = tagName
+        }
+
+        val tagIds =
+            PortfolioTagNameTable.selectAll()
+                .where { PortfolioTagNameTable.name inList tags }
+                .map { it[PortfolioTagNameTable.id] }
+
+        PortfolioTagsTable.batchInsert(tagIds) { tagId ->
+            this[PortfolioTagsTable.portfolioId] = portfolioId
+            this[PortfolioTagsTable.tagId] = tagId
+        }
+    }
+
+    private fun parseDate(dateString: String): LocalDateTime {
+        return try {
+            LocalDate.parse(dateString, dateFormatter).atStartOfDay()
+        } catch (e: Exception) {
+            LocalDateTime.now()
+        }
+    }
+
+    private fun escapeLikePattern(keyword: String): String {
+        return keyword
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+    }
+}

--- a/backend/app/src/main/kotlin/my/backend/routes/AuthRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/AuthRoutes.kt
@@ -27,6 +27,7 @@ fun Route.authRoutes(authService: AuthService) {
                             secure = System.getenv("KTOR_ENV") == "production",
                             path = "/",
                             maxAge = 3600,
+                            extensions = mapOf("SameSite" to "Strict"),
                         ),
                     )
                     call.respond(HttpStatusCode.OK)

--- a/backend/app/src/main/kotlin/my/backend/routes/BlogRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/BlogRoutes.kt
@@ -12,7 +12,7 @@ import my.backend.service.BlogService
 fun Route.blogRoutes(blogService: BlogService) {
     route("/api/blogs") {
         get {
-            val limit = call.request.queryParameters["limit"]?.toIntOrNull()
+            val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: BlogService.MAX_LIMIT
             val tags = call.request.queryParameters.getAll("tags")
             val keyword = call.request.queryParameters["keyword"]
 

--- a/backend/app/src/main/kotlin/my/backend/routes/PortfolioRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/PortfolioRoutes.kt
@@ -13,10 +13,7 @@ fun Route.portfolioRoutes(portfolioService: PortfolioService) {
     route("/api/portfolios") {
         get {
             val limit = call.request.queryParameters["limit"]?.toIntOrNull()
-            val tags = call.request.queryParameters.getAll("tags")
-            val keyword = call.request.queryParameters["keyword"]
-
-            val portfolios = portfolioService.getPortfolios(limit, tags, keyword)
+            val portfolios = portfolioService.getPortfolios(limit)
             call.respond(portfolios)
         }
 

--- a/backend/app/src/main/kotlin/my/backend/routes/PortfolioRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/PortfolioRoutes.kt
@@ -12,7 +12,7 @@ import my.backend.service.PortfolioService
 fun Route.portfolioRoutes(portfolioService: PortfolioService) {
     route("/api/portfolios") {
         get {
-            val limit = call.request.queryParameters["limit"]?.toIntOrNull()
+            val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: PortfolioService.MAX_LIMIT
             val portfolios = portfolioService.getPortfolios(limit)
             call.respond(portfolios)
         }

--- a/backend/app/src/main/kotlin/my/backend/routes/PortfolioRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/PortfolioRoutes.kt
@@ -2,15 +2,21 @@ package my.backend.routes
 
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import my.backend.dto.PortfolioRequestDto
 import my.backend.service.PortfolioService
 
 fun Route.portfolioRoutes(portfolioService: PortfolioService) {
     route("/api/portfolios") {
         get {
             val limit = call.request.queryParameters["limit"]?.toIntOrNull()
-            val portfolios = portfolioService.getPortfolios(limit)
+            val tags = call.request.queryParameters.getAll("tags")
+            val keyword = call.request.queryParameters["keyword"]
+
+            val portfolios = portfolioService.getPortfolios(limit, tags, keyword)
             call.respond(portfolios)
         }
 
@@ -21,6 +27,35 @@ fun Route.portfolioRoutes(portfolioService: PortfolioService) {
                 call.respond(portfolio)
             } else {
                 call.respond(HttpStatusCode.NotFound)
+            }
+        }
+
+        authenticate("auth-jwt") {
+            post {
+                val portfolio = call.receive<PortfolioRequestDto>()
+                val created = portfolioService.createPortfolio(portfolio)
+                call.respond(HttpStatusCode.Created, created)
+            }
+
+            put("/{slug}") {
+                val slug = call.parameters["slug"] ?: return@put call.respond(HttpStatusCode.BadRequest)
+                val portfolio = call.receive<PortfolioRequestDto>()
+                val updated = portfolioService.updatePortfolio(slug, portfolio)
+                if (updated != null) {
+                    call.respond(updated)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
+                }
+            }
+
+            delete("/{slug}") {
+                val slug = call.parameters["slug"] ?: return@delete call.respond(HttpStatusCode.BadRequest)
+                val deleted = portfolioService.deletePortfolio(slug)
+                if (deleted) {
+                    call.respond(HttpStatusCode.NoContent)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
+                }
             }
         }
     }

--- a/backend/app/src/main/kotlin/my/backend/service/BlogService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/BlogService.kt
@@ -3,6 +3,7 @@ package my.backend.service
 import my.backend.dto.BlogRequestDto
 import my.backend.dto.BlogResponseDto
 import my.backend.repository.BlogRepository
+import my.backend.util.stripHtmlTags
 
 class BlogService(private val blogRepository: BlogRepository) {
     companion object {
@@ -25,15 +26,21 @@ class BlogService(private val blogRepository: BlogRepository) {
     }
 
     suspend fun createBlog(blog: BlogRequestDto): BlogResponseDto {
-        return blogRepository.create(blog)
+        return blogRepository.create(blog.sanitized())
     }
 
     suspend fun updateBlog(
         slug: String,
         blog: BlogRequestDto,
     ): BlogResponseDto? {
-        return blogRepository.update(slug, blog)
+        return blogRepository.update(slug, blog.sanitized())
     }
+
+    private fun BlogRequestDto.sanitized() =
+        copy(
+            title = title.stripHtmlTags(),
+            description = description.stripHtmlTags(),
+        )
 
     suspend fun deleteBlog(slug: String): Boolean {
         return blogRepository.delete(slug)

--- a/backend/app/src/main/kotlin/my/backend/service/BlogService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/BlogService.kt
@@ -5,11 +5,18 @@ import my.backend.dto.BlogResponseDto
 import my.backend.repository.BlogRepository
 
 class BlogService(private val blogRepository: BlogRepository) {
+    companion object {
+        const val MAX_LIMIT = 100
+    }
+
     suspend fun getBlogs(
-        limit: Int?,
-        tags: List<String>?,
-        keyword: String?,
+        limit: Int = MAX_LIMIT,
+        tags: List<String>? = null,
+        keyword: String? = null,
     ): List<BlogResponseDto> {
+        if (limit > MAX_LIMIT) {
+            throw IllegalArgumentException("limit の最大値は $MAX_LIMIT です。")
+        }
         return blogRepository.findAll(limit, tags, keyword)
     }
 

--- a/backend/app/src/main/kotlin/my/backend/service/PortfolioService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/PortfolioService.kt
@@ -5,12 +5,8 @@ import my.backend.dto.PortfolioResponseDto
 import my.backend.repository.PortfolioRepository
 
 class PortfolioService(private val portfolioRepository: PortfolioRepository) {
-    suspend fun getPortfolios(
-        limit: Int?,
-        tags: List<String>? = null,
-        keyword: String? = null,
-    ): List<PortfolioResponseDto> {
-        return portfolioRepository.findAll(limit, tags, keyword)
+    suspend fun getPortfolios(limit: Int?): List<PortfolioResponseDto> {
+        return portfolioRepository.findAll(limit)
     }
 
     suspend fun getPortfolioBySlug(slug: String): PortfolioResponseDto? {

--- a/backend/app/src/main/kotlin/my/backend/service/PortfolioService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/PortfolioService.kt
@@ -1,99 +1,34 @@
 package my.backend.service
 
-import com.vladsch.flexmark.ext.autolink.AutolinkExtension
-import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
-import com.vladsch.flexmark.ext.tables.TablesExtension
-import com.vladsch.flexmark.html.HtmlRenderer
-import com.vladsch.flexmark.parser.Parser
-import com.vladsch.flexmark.util.data.MutableDataSet
-import my.backend.dto.PortfolioDto
-import org.yaml.snakeyaml.Yaml
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.nio.charset.StandardCharsets
+import my.backend.dto.PortfolioRequestDto
+import my.backend.dto.PortfolioResponseDto
+import my.backend.repository.PortfolioRepository
 
-class PortfolioService {
-    private val parser: Parser
-    private val renderer: HtmlRenderer
-    private val portfolios: List<PortfolioDto>
-
-    init {
-        val options = MutableDataSet()
-        options.set(
-            Parser.EXTENSIONS,
-            listOf(
-                TablesExtension.create(),
-                StrikethroughExtension.create(),
-                AutolinkExtension.create(),
-            ),
-        )
-        parser = Parser.builder(options).build()
-        renderer = HtmlRenderer.builder(options).build()
-
-        portfolios = loadPortfolios()
+class PortfolioService(private val portfolioRepository: PortfolioRepository) {
+    suspend fun getPortfolios(
+        limit: Int?,
+        tags: List<String>? = null,
+        keyword: String? = null,
+    ): List<PortfolioResponseDto> {
+        return portfolioRepository.findAll(limit, tags, keyword)
     }
 
-    fun getPortfolios(limit: Int?): List<PortfolioDto> {
-        return portfolios.take(limit ?: portfolios.size)
+    suspend fun getPortfolioBySlug(slug: String): PortfolioResponseDto? {
+        return portfolioRepository.findBySlug(slug)
     }
 
-    fun getPortfolioBySlug(slug: String): PortfolioDto? {
-        return portfolios.find { it.slug == slug }
+    suspend fun createPortfolio(portfolio: PortfolioRequestDto): PortfolioResponseDto {
+        return portfolioRepository.create(portfolio)
     }
 
-    private fun loadPortfolios(): List<PortfolioDto> {
-        val yaml = Yaml()
+    suspend fun updatePortfolio(
+        slug: String,
+        portfolio: PortfolioRequestDto,
+    ): PortfolioResponseDto? {
+        return portfolioRepository.update(slug, portfolio)
+    }
 
-        val indexStream =
-            javaClass.classLoader.getResourceAsStream("portfolios/index.txt") ?: return emptyList()
-
-        val fileNames =
-            indexStream.use { stream ->
-                BufferedReader(InputStreamReader(stream, StandardCharsets.UTF_8))
-                    .readLines()
-                    .filter { it.isNotBlank() }
-            }
-
-        return fileNames
-            .mapNotNull { fileName ->
-                val resourceStream =
-                    javaClass.classLoader.getResourceAsStream("portfolios/$fileName")
-                        ?: return@mapNotNull null
-
-                val content =
-                    resourceStream.use { stream ->
-                        stream.bufferedReader(StandardCharsets.UTF_8).readText()
-                    }
-                val parts = content.split("---", limit = 3)
-                val frontMatter = parts.getOrNull(1) ?: ""
-                val markdownBody = parts.getOrNull(2) ?: ""
-
-                val meta: Map<String, Any> = yaml.load(frontMatter) ?: emptyMap()
-                val contentHtml = renderer.render(parser.parse(markdownBody))
-
-                @Suppress("UNCHECKED_CAST")
-                PortfolioDto(
-                    slug = fileName.replace(".md", ""),
-                    title = meta["title"] as? String ?: "",
-                    date = meta["date"] as? String ?: "",
-                    description = meta["description"] as? String ?: "",
-                    coverImage = meta["coverImage"] as? String,
-                    tags = meta["tags"] as? List<String> ?: emptyList(),
-                    content = contentHtml,
-                )
-            }
-            .sortedByDescending {
-                try {
-                    java.time.LocalDate.parse(
-                        it.date,
-                        java.time.format.DateTimeFormatter.ofPattern(
-                            "yyyy年M月d日",
-                            java.util.Locale.JAPAN,
-                        ),
-                    )
-                } catch (e: java.time.format.DateTimeParseException) {
-                    java.time.LocalDate.MIN
-                }
-            }
+    suspend fun deletePortfolio(slug: String): Boolean {
+        return portfolioRepository.delete(slug)
     }
 }

--- a/backend/app/src/main/kotlin/my/backend/service/PortfolioService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/PortfolioService.kt
@@ -3,6 +3,7 @@ package my.backend.service
 import my.backend.dto.PortfolioRequestDto
 import my.backend.dto.PortfolioResponseDto
 import my.backend.repository.PortfolioRepository
+import my.backend.util.stripHtmlTags
 
 class PortfolioService(private val portfolioRepository: PortfolioRepository) {
     companion object {
@@ -21,15 +22,21 @@ class PortfolioService(private val portfolioRepository: PortfolioRepository) {
     }
 
     suspend fun createPortfolio(portfolio: PortfolioRequestDto): PortfolioResponseDto {
-        return portfolioRepository.create(portfolio)
+        return portfolioRepository.create(portfolio.sanitized())
     }
 
     suspend fun updatePortfolio(
         slug: String,
         portfolio: PortfolioRequestDto,
     ): PortfolioResponseDto? {
-        return portfolioRepository.update(slug, portfolio)
+        return portfolioRepository.update(slug, portfolio.sanitized())
     }
+
+    private fun PortfolioRequestDto.sanitized() =
+        copy(
+            title = title.stripHtmlTags(),
+            description = description.stripHtmlTags(),
+        )
 
     suspend fun deletePortfolio(slug: String): Boolean {
         return portfolioRepository.delete(slug)

--- a/backend/app/src/main/kotlin/my/backend/service/PortfolioService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/PortfolioService.kt
@@ -5,7 +5,14 @@ import my.backend.dto.PortfolioResponseDto
 import my.backend.repository.PortfolioRepository
 
 class PortfolioService(private val portfolioRepository: PortfolioRepository) {
-    suspend fun getPortfolios(limit: Int?): List<PortfolioResponseDto> {
+    companion object {
+        const val MAX_LIMIT = 100
+    }
+
+    suspend fun getPortfolios(limit: Int = MAX_LIMIT): List<PortfolioResponseDto> {
+        if (limit > MAX_LIMIT) {
+            throw IllegalArgumentException("limit の最大値は $MAX_LIMIT です。")
+        }
         return portfolioRepository.findAll(limit)
     }
 

--- a/backend/app/src/main/kotlin/my/backend/util/DateParser.kt
+++ b/backend/app/src/main/kotlin/my/backend/util/DateParser.kt
@@ -1,0 +1,19 @@
+package my.backend.util
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
+
+private val dateFormatter = DateTimeFormatter.ofPattern("yyyy年M月d日", Locale.JAPAN)
+
+fun parseDateToLocalDateTime(dateString: String): LocalDateTime {
+    return try {
+        LocalDate.parse(dateString, dateFormatter).atStartOfDay()
+    } catch (e: DateTimeParseException) {
+        throw IllegalArgumentException("Invalid date format for '$dateString'. Expected format 'yyyy年M月d日'.", e)
+    }
+}
+
+fun formatLocalDateTime(dateTime: LocalDateTime): String = dateTime.format(dateFormatter)

--- a/backend/app/src/main/kotlin/my/backend/util/DateParser.kt
+++ b/backend/app/src/main/kotlin/my/backend/util/DateParser.kt
@@ -6,14 +6,14 @@ import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.Locale
 
-private val dateFormatter = DateTimeFormatter.ofPattern("yyyy年M月d日", Locale.JAPAN)
+object DateParser {
+    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy年M月d日", Locale.JAPAN)
 
-fun parseDateToLocalDateTime(dateString: String): LocalDateTime {
-    return try {
-        LocalDate.parse(dateString, dateFormatter).atStartOfDay()
-    } catch (e: DateTimeParseException) {
-        throw IllegalArgumentException("Invalid date format for '$dateString'. Expected format 'yyyy年M月d日'.", e)
+    fun parseDateToLocalDateTime(dateString: String): LocalDateTime {
+        return try {
+            LocalDate.parse(dateString, dateFormatter).atStartOfDay()
+        } catch (e: DateTimeParseException) {
+            throw IllegalArgumentException("Invalid date format for '$dateString'. Expected format 'yyyy年M月d日'.", e)
+        }
     }
 }
-
-fun formatLocalDateTime(dateTime: LocalDateTime): String = dateTime.format(dateFormatter)

--- a/backend/app/src/main/kotlin/my/backend/util/HtmlSanitizer.kt
+++ b/backend/app/src/main/kotlin/my/backend/util/HtmlSanitizer.kt
@@ -1,0 +1,11 @@
+package my.backend.util
+
+import org.jsoup.Jsoup
+import org.jsoup.safety.Safelist
+
+/**
+ * 文字列からすべてのHTMLタグおよびHTMLエンティティを除去する。
+ * title / description のようなプレーンテキストフィールドの XSS 対策として使用する。
+ * content（Markdown）フィールドは対象外とし、フロントエンド側でのサニタイズに委ねる。
+ */
+fun String.stripHtmlTags(): String = Jsoup.clean(this, Safelist.none())

--- a/backend/app/src/main/resources/db/migration/V3__create_portfolio_tables.sql
+++ b/backend/app/src/main/resources/db/migration/V3__create_portfolio_tables.sql
@@ -1,0 +1,24 @@
+CREATE TABLE portfolio_tag_names (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+    CONSTRAINT uk_portfolio_tag_names_name UNIQUE (name)
+);
+
+CREATE TABLE portfolios (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    slug VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    content TEXT NOT NULL,
+    cover_image VARCHAR(255) NULL,
+    date DATETIME NOT NULL,
+    CONSTRAINT uk_portfolios_slug UNIQUE (slug)
+);
+
+CREATE TABLE portfolio_tags (
+    portfolio_id INT NOT NULL,
+    tag_id INT NOT NULL,
+    PRIMARY KEY (portfolio_id, tag_id),
+    CONSTRAINT fk_portfolio_tags_portfolio_id FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_portfolio_tags_tag_id FOREIGN KEY (tag_id) REFERENCES portfolio_tag_names(id) ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/backend/app/src/main/resources/db/migration/V3__create_portfolio_tables.sql
+++ b/backend/app/src/main/resources/db/migration/V3__create_portfolio_tables.sql
@@ -1,9 +1,3 @@
-CREATE TABLE portfolio_tag_names (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,
-    CONSTRAINT uk_portfolio_tag_names_name UNIQUE (name)
-);
-
 CREATE TABLE portfolios (
     id INT AUTO_INCREMENT PRIMARY KEY,
     slug VARCHAR(255) NOT NULL,
@@ -13,12 +7,4 @@ CREATE TABLE portfolios (
     cover_image VARCHAR(255) NULL,
     date DATETIME NOT NULL,
     CONSTRAINT uk_portfolios_slug UNIQUE (slug)
-);
-
-CREATE TABLE portfolio_tags (
-    portfolio_id INT NOT NULL,
-    tag_id INT NOT NULL,
-    PRIMARY KEY (portfolio_id, tag_id),
-    CONSTRAINT fk_portfolio_tags_portfolio_id FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT fk_portfolio_tags_tag_id FOREIGN KEY (tag_id) REFERENCES portfolio_tag_names(id) ON DELETE CASCADE ON UPDATE CASCADE
 );

--- a/backend/app/src/test/kotlin/my/backend/routes/ContactRoutesTest.kt
+++ b/backend/app/src/test/kotlin/my/backend/routes/ContactRoutesTest.kt
@@ -19,6 +19,7 @@ class ContactRoutesTest {
             jsonClient
                 .post("/api/contact") {
                     contentType(ContentType.Application.Json)
+                    header(HttpHeaders.Origin, "http://localhost:3000")
                     setBody("""{"email":"","subject":"","message":"","turnstileToken":""}""")
                 }
                 .apply {
@@ -35,6 +36,7 @@ class ContactRoutesTest {
             jsonClient
                 .post("/api/contact") {
                     contentType(ContentType.Application.Json)
+                    header(HttpHeaders.Origin, "http://localhost:3000")
                     setBody(
                         """{"email":"invalid-email","subject":"テスト件名",""" +
                             """"message":"これはテストメッセージです。","turnstileToken":"test-token"}""",
@@ -54,6 +56,7 @@ class ContactRoutesTest {
             jsonClient
                 .post("/api/contact") {
                     contentType(ContentType.Application.Json)
+                    header(HttpHeaders.Origin, "http://localhost:3000")
                     setBody(
                         """{"email":"test@example.com","subject":"ab",""" +
                             """"message":"これはテストメッセージです。","turnstileToken":"test-token"}""",
@@ -73,6 +76,7 @@ class ContactRoutesTest {
             jsonClient
                 .post("/api/contact") {
                     contentType(ContentType.Application.Json)
+                    header(HttpHeaders.Origin, "http://localhost:3000")
                     setBody(
                         """{"email":"test@example.com","subject":"テスト件名",""" +
                             """"message":"短い","turnstileToken":"test-token"}""",

--- a/backend/app/src/test/kotlin/my/backend/testutil/TestKtorApplication.kt
+++ b/backend/app/src/test/kotlin/my/backend/testutil/TestKtorApplication.kt
@@ -52,6 +52,7 @@ private fun h2TestConfig(): MapApplicationConfig =
         put("app.resend.from-email", "no-reply@example.com")
         put("app.turnstile.secret-key", "dummy_secret")
         put("app.contact.recipient-email", "recipient@example.com")
+        put("app.cors.allowed-origins", "http://localhost:3000")
     }
 
 /**

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ exposed = "0.50.0"
 hikaricp = "5.1.0"
 flyway = "11.19.0"
 h2 = "2.2.224"
+jsoup = "1.18.1"
 jbcrypt = "0.4"
 jnanoid = "2.0.0"
 
@@ -34,6 +35,7 @@ exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", versio
 
 h2 = { module = "com.h2database:h2", version.ref = "h2" }
 jbcrypt = { module = "org.mindrot:jbcrypt", version.ref = "jbcrypt" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 jnanoid = { module = "com.aventrix.jnanoid:jnanoid", version.ref = "jnanoid" }
 
 [plugins]

--- a/frontend/src/app/repository/portfolioRepository.ts
+++ b/frontend/src/app/repository/portfolioRepository.ts
@@ -6,7 +6,6 @@ export type Portfolio = {
   date: string;
   description: string;
   coverImage?: string | undefined;
-  tags?: string[];
   content: string;
 };
 


### PR DESCRIPTION
## 変更内容
- 基本的にはブログと一致している実装
- フロントでデータが取れない（既存のmdデータを経由していない）ことを確認
  - mdについてはフロントが対応済みに削除する
- ポートフォリオからタグは削除
- `DateParser` を共通化

## 該当するissue

<!-- もしあれば -->

- close #85 