### PR TITLE
[Frontend/Backend] タグの二重管理を解消しadminで選択式にする

### DIFF
--- a/backend/app/src/main/kotlin/my/backend/db/schema/BlogTable.kt
+++ b/backend/app/src/main/kotlin/my/backend/db/schema/BlogTable.kt
@@ -13,17 +13,3 @@ object BlogTable : Table("blogs") {
 
     override val primaryKey = PrimaryKey(id)
 }
-
-object TagTable : Table("tags") {
-    val id = integer("id").autoIncrement()
-    val name = varchar("name", 50).uniqueIndex()
-
-    override val primaryKey = PrimaryKey(id)
-}
-
-object BlogTagsTable : Table("blog_tags") {
-    val blogId = reference("blog_id", BlogTable.id)
-    val tagId = reference("tag_id", TagTable.id)
-
-    override val primaryKey = PrimaryKey(blogId, tagId)
-}

--- a/backend/app/src/main/kotlin/my/backend/db/schema/TagTable.kt
+++ b/backend/app/src/main/kotlin/my/backend/db/schema/TagTable.kt
@@ -1,0 +1,17 @@
+package my.backend.db.schema
+
+import org.jetbrains.exposed.sql.Table
+
+object TagTable : Table("tags") {
+    val id = integer("id").autoIncrement()
+    val name = varchar("name", 50).uniqueIndex()
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object BlogTagsTable : Table("blog_tags") {
+    val blogId = reference("blog_id", BlogTable.id)
+    val tagId = reference("tag_id", TagTable.id)
+
+    override val primaryKey = PrimaryKey(blogId, tagId)
+}

--- a/backend/app/src/main/kotlin/my/backend/di/AppModule.kt
+++ b/backend/app/src/main/kotlin/my/backend/di/AppModule.kt
@@ -14,12 +14,15 @@ import my.backend.repository.BlogRepository
 import my.backend.repository.BlogRepositoryImpl
 import my.backend.repository.PortfolioRepository
 import my.backend.repository.PortfolioRepositoryImpl
+import my.backend.repository.TagRepository
+import my.backend.repository.TagRepositoryImpl
 import my.backend.repository.UserRepository
 import my.backend.repository.UserRepositoryImpl
 import my.backend.service.AuthService
 import my.backend.service.BlogService
 import my.backend.service.ContactService
 import my.backend.service.PortfolioService
+import my.backend.service.TagService
 import org.koin.dsl.module
 import org.koin.dsl.onClose
 
@@ -60,10 +63,12 @@ fun appModule(config: ApplicationConfig) =
         single<BlogRepository> { BlogRepositoryImpl() }
         single<UserRepository> { UserRepositoryImpl() }
         single<PortfolioRepository> { PortfolioRepositoryImpl() }
+        single<TagRepository> { TagRepositoryImpl() }
 
         // Services
         single { BlogService(get()) }
         single { ContactService(get(), get(), get()) }
         single { PortfolioService(get()) }
         single { AuthService(get(), get()) }
+        single { TagService(get()) }
     }

--- a/backend/app/src/main/kotlin/my/backend/dto/TagDto.kt
+++ b/backend/app/src/main/kotlin/my/backend/dto/TagDto.kt
@@ -1,0 +1,9 @@
+package my.backend.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TagResponseDto(val id: Int, val name: String)
+
+@Serializable
+data class TagRequestDto(val name: String)

--- a/backend/app/src/main/kotlin/my/backend/exception/CustomExceptions.kt
+++ b/backend/app/src/main/kotlin/my/backend/exception/CustomExceptions.kt
@@ -3,3 +3,5 @@ package my.backend.exception
 class InvalidOriginException(message: String) : RuntimeException(message)
 
 class TurnstileVerificationException(message: String) : RuntimeException(message)
+
+class DuplicateTagException(name: String) : RuntimeException("タグ「$name」はすでに存在します。")

--- a/backend/app/src/main/kotlin/my/backend/plugins/Routing.kt
+++ b/backend/app/src/main/kotlin/my/backend/plugins/Routing.kt
@@ -7,10 +7,12 @@ import my.backend.routes.authRoutes
 import my.backend.routes.blogRoutes
 import my.backend.routes.contactRoutes
 import my.backend.routes.portfolioRoutes
+import my.backend.routes.tagRoutes
 import my.backend.service.AuthService
 import my.backend.service.BlogService
 import my.backend.service.ContactService
 import my.backend.service.PortfolioService
+import my.backend.service.TagService
 import org.koin.ktor.ext.inject
 
 fun Application.configureRouting() {
@@ -18,12 +20,14 @@ fun Application.configureRouting() {
     val contactService by inject<ContactService>()
     val portfolioService by inject<PortfolioService>()
     val authService by inject<AuthService>()
+    val tagService by inject<TagService>()
 
     routing {
         blogRoutes(blogService)
         contactRoutes(contactService)
         portfolioRoutes(portfolioService)
         authRoutes(authService)
+        tagRoutes(tagService)
 
         staticResources("/images", "static/images")
     }

--- a/backend/app/src/main/kotlin/my/backend/plugins/StatusPages.kt
+++ b/backend/app/src/main/kotlin/my/backend/plugins/StatusPages.kt
@@ -8,6 +8,7 @@ import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import my.backend.dto.ApiResponse
 import my.backend.dto.ValidationErrors
+import my.backend.exception.DuplicateTagException
 import my.backend.exception.InvalidOriginException
 import my.backend.exception.TurnstileVerificationException
 import org.slf4j.LoggerFactory
@@ -33,6 +34,15 @@ fun Application.configureStatusPages() {
     val logger = LoggerFactory.getLogger("StatusPages")
 
     install(StatusPages) {
+        // タグ重複エラー
+        exception<DuplicateTagException> { call, cause ->
+            logger.warn("Duplicate tag: ${cause.message}")
+            call.respond(
+                HttpStatusCode.Conflict,
+                ApiResponse(error = cause.message ?: "タグが重複しています。"),
+            )
+        }
+
         // バリデーションエラー
         exception<RequestValidationException> { call, cause ->
             val errors = cause.reasons

--- a/backend/app/src/main/kotlin/my/backend/repository/TagRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/TagRepository.kt
@@ -2,16 +2,17 @@ package my.backend.repository
 
 import my.backend.db.schema.TagTable
 import my.backend.dto.TagResponseDto
-import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import org.jetbrains.exposed.sql.update
 
 interface TagRepository {
     suspend fun findAll(): List<TagResponseDto>
+
+    suspend fun existsByName(
+        name: String,
+        excludeId: Int? = null,
+    ): Boolean
 
     suspend fun create(name: String): TagResponseDto
 
@@ -29,6 +30,22 @@ class TagRepositoryImpl : TagRepository {
             TagTable.selectAll()
                 .orderBy(TagTable.name to SortOrder.ASC)
                 .map { TagResponseDto(it[TagTable.id], it[TagTable.name]) }
+        }
+
+    override suspend fun existsByName(
+        name: String,
+        excludeId: Int?,
+    ): Boolean =
+        newSuspendedTransaction {
+            TagTable.selectAll()
+                .where {
+                    if (excludeId != null) {
+                        (TagTable.name eq name) and (TagTable.id neq excludeId)
+                    } else {
+                        TagTable.name eq name
+                    }
+                }
+                .count() > 0
         }
 
     override suspend fun create(name: String): TagResponseDto =

--- a/backend/app/src/main/kotlin/my/backend/repository/TagRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/TagRepository.kt
@@ -45,7 +45,7 @@ class TagRepositoryImpl : TagRepository {
                         TagTable.name eq name
                     }
                 }
-                .count() > 0
+                .any()
         }
 
     override suspend fun create(name: String): TagResponseDto =

--- a/backend/app/src/main/kotlin/my/backend/repository/TagRepository.kt
+++ b/backend/app/src/main/kotlin/my/backend/repository/TagRepository.kt
@@ -1,0 +1,59 @@
+package my.backend.repository
+
+import my.backend.db.schema.TagTable
+import my.backend.dto.TagResponseDto
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.update
+
+interface TagRepository {
+    suspend fun findAll(): List<TagResponseDto>
+
+    suspend fun create(name: String): TagResponseDto
+
+    suspend fun update(
+        id: Int,
+        name: String,
+    ): TagResponseDto?
+
+    suspend fun delete(id: Int): Boolean
+}
+
+class TagRepositoryImpl : TagRepository {
+    override suspend fun findAll(): List<TagResponseDto> =
+        newSuspendedTransaction {
+            TagTable.selectAll()
+                .orderBy(TagTable.name to SortOrder.ASC)
+                .map { TagResponseDto(it[TagTable.id], it[TagTable.name]) }
+        }
+
+    override suspend fun create(name: String): TagResponseDto =
+        newSuspendedTransaction {
+            val id =
+                TagTable.insert {
+                    it[TagTable.name] = name
+                } get TagTable.id
+            TagResponseDto(id, name)
+        }
+
+    override suspend fun update(
+        id: Int,
+        name: String,
+    ): TagResponseDto? =
+        newSuspendedTransaction {
+            val updated =
+                TagTable.update({ TagTable.id eq id }) {
+                    it[TagTable.name] = name
+                }
+            if (updated == 0) null else TagResponseDto(id, name)
+        }
+
+    override suspend fun delete(id: Int): Boolean =
+        newSuspendedTransaction {
+            TagTable.deleteWhere { TagTable.id eq id } > 0
+        }
+}

--- a/backend/app/src/main/kotlin/my/backend/routes/TagRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/TagRoutes.kt
@@ -1,0 +1,51 @@
+package my.backend.routes
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import my.backend.dto.TagRequestDto
+import my.backend.service.TagService
+
+fun Route.tagRoutes(tagService: TagService) {
+    route("/api/tags") {
+        get {
+            call.respond(tagService.getTags())
+        }
+
+        authenticate("auth-jwt") {
+            post {
+                val request = call.receive<TagRequestDto>()
+                val created = tagService.createTag(request.name)
+                call.respond(HttpStatusCode.Created, created)
+            }
+
+            put("/{id}") {
+                val id =
+                    call.parameters["id"]?.toIntOrNull()
+                        ?: return@put call.respond(HttpStatusCode.BadRequest)
+                val request = call.receive<TagRequestDto>()
+                val updated = tagService.updateTag(id, request.name)
+                if (updated != null) {
+                    call.respond(updated)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
+                }
+            }
+
+            delete("/{id}") {
+                val id =
+                    call.parameters["id"]?.toIntOrNull()
+                        ?: return@delete call.respond(HttpStatusCode.BadRequest)
+                val deleted = tagService.deleteTag(id)
+                if (deleted) {
+                    call.respond(HttpStatusCode.NoContent)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
+                }
+            }
+        }
+    }
+}

--- a/backend/app/src/main/kotlin/my/backend/service/TagService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/TagService.kt
@@ -1,17 +1,24 @@
 package my.backend.service
 
 import my.backend.dto.TagResponseDto
+import my.backend.exception.DuplicateTagException
 import my.backend.repository.TagRepository
 
 class TagService(private val tagRepository: TagRepository) {
     suspend fun getTags(): List<TagResponseDto> = tagRepository.findAll()
 
-    suspend fun createTag(name: String): TagResponseDto = tagRepository.create(name)
+    suspend fun createTag(name: String): TagResponseDto {
+        if (tagRepository.existsByName(name)) throw DuplicateTagException(name)
+        return tagRepository.create(name)
+    }
 
     suspend fun updateTag(
         id: Int,
         name: String,
-    ): TagResponseDto? = tagRepository.update(id, name)
+    ): TagResponseDto? {
+        if (tagRepository.existsByName(name, excludeId = id)) throw DuplicateTagException(name)
+        return tagRepository.update(id, name)
+    }
 
     suspend fun deleteTag(id: Int): Boolean = tagRepository.delete(id)
 }

--- a/backend/app/src/main/kotlin/my/backend/service/TagService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/TagService.kt
@@ -1,0 +1,17 @@
+package my.backend.service
+
+import my.backend.dto.TagResponseDto
+import my.backend.repository.TagRepository
+
+class TagService(private val tagRepository: TagRepository) {
+    suspend fun getTags(): List<TagResponseDto> = tagRepository.findAll()
+
+    suspend fun createTag(name: String): TagResponseDto = tagRepository.create(name)
+
+    suspend fun updateTag(
+        id: Int,
+        name: String,
+    ): TagResponseDto? = tagRepository.update(id, name)
+
+    suspend fun deleteTag(id: Int): Boolean = tagRepository.delete(id)
+}

--- a/backend/app/src/test/kotlin/my/backend/routes/TagRoutesTest.kt
+++ b/backend/app/src/test/kotlin/my/backend/routes/TagRoutesTest.kt
@@ -1,0 +1,243 @@
+package my.backend.routes
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import my.backend.testutil.testApplicationWithH2
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TagRoutesTest {
+    private fun generateTestJwt(): String =
+        JWT
+            .create()
+            .withAudience("test_audience")
+            .withIssuer("test_issuer")
+            .withClaim("username", "testuser")
+            .sign(Algorithm.HMAC256("test_secret_key_1234567890"))
+
+    private fun HttpRequestBuilder.allowedOrigin() {
+        header(HttpHeaders.Origin, "http://localhost:3000")
+    }
+
+    private suspend fun createTag(
+        client: io.ktor.client.HttpClient,
+        token: String,
+        name: String,
+    ): Int {
+        val body =
+            client.post("/api/tags") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"$name"}""")
+            }.bodyAsText()
+        return Json.parseToJsonElement(body).jsonObject["id"]!!.jsonPrimitive.int
+    }
+
+    // --- GET /api/tags ---
+
+    @Test
+    fun `タグ一覧を取得できる`() =
+        testApplicationWithH2 {
+            client.get("/api/tags").apply {
+                assertEquals(HttpStatusCode.OK, status)
+                assertTrue(bodyAsText().contains("["))
+            }
+        }
+
+    // --- POST /api/tags ---
+
+    @Test
+    fun `認証なしでタグを作成すると401を返す`() =
+        testApplicationWithH2 {
+            client.post("/api/tags") {
+                allowedOrigin()
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"未認証タグ"}""")
+            }.apply {
+                assertEquals(HttpStatusCode.Unauthorized, status)
+            }
+        }
+
+    @Test
+    fun `タグを作成できる`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            client.post("/api/tags") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"新規タグ_create"}""")
+            }.apply {
+                assertEquals(HttpStatusCode.Created, status)
+                assertTrue(bodyAsText().contains("新規タグ_create"))
+            }
+        }
+
+    @Test
+    fun `作成したタグが一覧に反映される`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            client.post("/api/tags") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"一覧確認タグ"}""")
+            }
+            client.get("/api/tags").apply {
+                assertEquals(HttpStatusCode.OK, status)
+                assertTrue(bodyAsText().contains("一覧確認タグ"))
+            }
+        }
+
+    @Test
+    fun `同じ名前のタグは登録できない`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            client.post("/api/tags") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"重複テストタグ"}""")
+            }.apply {
+                assertEquals(HttpStatusCode.Created, status)
+            }
+            client.post("/api/tags") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"重複テストタグ"}""")
+            }.apply {
+                assertEquals(HttpStatusCode.Conflict, status)
+            }
+        }
+
+    // --- PUT /api/tags/{id} ---
+
+    @Test
+    fun `タグを更新できる`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            val id = createTag(client, token, "更新前タグ")
+
+            client.put("/api/tags/$id") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"更新後タグ"}""")
+            }.apply {
+                assertEquals(HttpStatusCode.OK, status)
+                assertTrue(bodyAsText().contains("更新後タグ"))
+            }
+        }
+
+    @Test
+    fun `タグを自分自身と同じ名前へ更新できる`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            val id = createTag(client, token, "同名更新タグ")
+
+            client.put("/api/tags/$id") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"同名更新タグ"}""")
+            }.apply {
+                assertEquals(HttpStatusCode.OK, status)
+            }
+        }
+
+    @Test
+    fun `別のタグと同じ名前への更新はできない`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            createTag(client, token, "重複更新タグA")
+            val idB = createTag(client, token, "重複更新タグB")
+
+            client.put("/api/tags/$idB") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"重複更新タグA"}""")
+            }.apply {
+                assertEquals(HttpStatusCode.Conflict, status)
+            }
+        }
+
+    @Test
+    fun `存在しないタグの更新は404を返す`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            client.put("/api/tags/99999") {
+                allowedOrigin()
+                cookie("auth_token", token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"存在しないタグ更新"}""")
+            }.apply {
+                assertEquals(HttpStatusCode.NotFound, status)
+            }
+        }
+
+    // --- DELETE /api/tags/{id} ---
+
+    @Test
+    fun `認証なしでタグを削除すると401を返す`() =
+        testApplicationWithH2 {
+            client.delete("/api/tags/1") {
+                allowedOrigin()
+            }.apply {
+                assertEquals(HttpStatusCode.Unauthorized, status)
+            }
+        }
+
+    @Test
+    fun `タグを削除できる`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            val id = createTag(client, token, "削除対象タグ")
+
+            client.delete("/api/tags/$id") {
+                allowedOrigin()
+                cookie("auth_token", token)
+            }.apply {
+                assertEquals(HttpStatusCode.NoContent, status)
+            }
+        }
+
+    @Test
+    fun `削除したタグは一覧に存在しない`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            val id = createTag(client, token, "削除後確認タグ")
+
+            client.delete("/api/tags/$id") {
+                allowedOrigin()
+                cookie("auth_token", token)
+            }
+
+            client.get("/api/tags").apply {
+                assertFalse(bodyAsText().contains("削除後確認タグ"))
+            }
+        }
+
+    @Test
+    fun `存在しないタグの削除は404を返す`() =
+        testApplicationWithH2 {
+            val token = generateTestJwt()
+            client.delete("/api/tags/99999") {
+                allowedOrigin()
+                cookie("auth_token", token)
+            }.apply {
+                assertEquals(HttpStatusCode.NotFound, status)
+            }
+        }
+}

--- a/frontend/src/app/admin/AdminTagTab.tsx
+++ b/frontend/src/app/admin/AdminTagTab.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import type { Tag } from "@/app/repository/adminTagRepository";
+
+type Props = {
+  tags: Tag[];
+  isLoading: boolean;
+  onCreate: (name: string) => Promise<void>;
+  onUpdate: (id: number, name: string) => Promise<void>;
+  onDelete: (id: number) => Promise<void>;
+};
+
+export default function AdminTagTab({
+  tags,
+  isLoading,
+  onCreate,
+  onUpdate,
+  onDelete,
+}: Props) {
+  const [newTagName, setNewTagName] = useState("");
+  const [createError, setCreateError] = useState("");
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [editError, setEditError] = useState("");
+
+  const isDuplicate = (name: string, excludeId?: number) =>
+    tags.some(
+      (t) =>
+        t.name === name.trim() &&
+        (excludeId === undefined || t.id !== excludeId),
+    );
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setCreateError("");
+    const trimmed = newTagName.trim();
+    if (!trimmed) return;
+    if (isDuplicate(trimmed)) {
+      setCreateError(`「${trimmed}」はすでに存在します。`);
+      return;
+    }
+    await onCreate(trimmed);
+    setNewTagName("");
+  };
+
+  const handleEditStart = (tag: Tag) => {
+    setEditingId(tag.id);
+    setEditingName(tag.name);
+    setEditError("");
+  };
+
+  const handleEditSave = async (id: number) => {
+    setEditError("");
+    const trimmed = editingName.trim();
+    if (!trimmed) return;
+    if (isDuplicate(trimmed, id)) {
+      setEditError(`「${trimmed}」はすでに存在します。`);
+      return;
+    }
+    await onUpdate(id, trimmed);
+    setEditingId(null);
+  };
+
+  const handleEditCancel = () => {
+    setEditingId(null);
+    setEditingName("");
+    setEditError("");
+  };
+
+  return (
+    <>
+      <div className="mb-6">
+        <form onSubmit={handleCreate} className="flex flex-col gap-1 max-w-sm">
+          <div className="flex gap-2">
+            <input
+              className="flex-1 rounded border px-3 py-2 shadow focus:outline-none"
+              type="text"
+              value={newTagName}
+              onChange={(e) => {
+                setNewTagName(e.target.value);
+                setCreateError("");
+              }}
+              placeholder="新しいタグ名"
+            />
+            <button
+              type="submit"
+              disabled={isLoading || !newTagName.trim()}
+              className="rounded bg-green-500 px-4 py-2 font-bold text-white hover:bg-green-700 disabled:opacity-50"
+            >
+              追加
+            </button>
+          </div>
+          {createError && <p className="text-sm text-red-500">{createError}</p>}
+        </form>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full overflow-hidden rounded-lg bg-white shadow-md">
+          <thead className="bg-gray-200 text-gray-700">
+            <tr>
+              <th className="px-4 py-3 text-left">タグ名</th>
+              <th className="px-4 py-3 text-left">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tags.map((tag) => (
+              <tr key={tag.id} className="border-b hover:bg-gray-50">
+                <td className="px-4 py-3">
+                  {editingId === tag.id ? (
+                    <div className="flex flex-col gap-1">
+                      <input
+                        className="rounded border px-2 py-1 focus:outline-none"
+                        value={editingName}
+                        onChange={(e) => {
+                          setEditingName(e.target.value);
+                          setEditError("");
+                        }}
+                      />
+                      {editError && (
+                        <p className="text-sm text-red-500">{editError}</p>
+                      )}
+                    </div>
+                  ) : (
+                    tag.name
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  {editingId === tag.id ? (
+                    <>
+                      <button
+                        onClick={() => handleEditSave(tag.id)}
+                        className="mr-2 text-blue-500 hover:text-blue-700"
+                        disabled={isLoading}
+                      >
+                        保存
+                      </button>
+                      <button
+                        onClick={handleEditCancel}
+                        className="text-gray-500 hover:text-gray-700"
+                      >
+                        キャンセル
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => handleEditStart(tag)}
+                        className="mr-2 text-blue-500 hover:text-blue-700"
+                      >
+                        編集
+                      </button>
+                      <button
+                        onClick={() => onDelete(tag.id)}
+                        className="ml-2 text-red-500 hover:text-red-700"
+                        disabled={isLoading}
+                      >
+                        削除
+                      </button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/app/admin/create/page.tsx
+++ b/frontend/src/app/admin/create/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminBlogCreate } from "@/app/hooks/admin/useAdminBlogCreate";
+import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
 
 export default function CreateBlogPage() {
   const router = useRouter();
@@ -16,13 +17,17 @@ export default function CreateBlogPage() {
       content,
       setContent,
       tags,
-      setTags,
+      toggleTag,
       date,
       setDate,
     },
     state: { isLoading },
     actions: { submitCreate },
   } = useAdminBlogCreate();
+
+  const {
+    state: { tags: availableTags },
+  } = useAdminTags({ onUnauthorized: () => router.push("/admin/login") });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -83,12 +88,21 @@ export default function CreateBlogPage() {
           <label className="mb-2 block text-sm font-bold text-gray-700">
             タグ
           </label>
-          <input
-            className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-            type="text"
-            value={tags}
-            onChange={(e) => setTags(e.target.value)}
-          />
+          <div className="flex flex-wrap gap-2">
+            {availableTags.map((tag) => (
+              <label
+                key={tag.id}
+                className="flex items-center gap-1 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={tags.includes(tag.name)}
+                  onChange={() => toggleTag(tag.name)}
+                />
+                <span>{tag.name}</span>
+              </label>
+            ))}
+          </div>
         </div>
         <div className="mb-6">
           <label className="mb-2 block text-sm font-bold text-gray-700">

--- a/frontend/src/app/admin/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/edit/[slug]/page.tsx
@@ -3,11 +3,14 @@
 import { useRouter, useParams } from "next/navigation";
 import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminBlogEdit } from "@/app/hooks/admin/useAdminBlogEdit";
+import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
 
 export default function EditBlogPage() {
   const router = useRouter();
   const params = useParams();
   const originalSlug = params.slug as string;
+
+  const handleUnauthorized = () => router.push("/admin/login");
 
   const {
     form: {
@@ -18,15 +21,17 @@ export default function EditBlogPage() {
       content,
       setContent,
       tags,
-      setTags,
+      toggleTag,
       date,
       setDate,
     },
     state: { isLoading },
     actions: { submitUpdate },
-  } = useAdminBlogEdit(originalSlug, {
-    onUnauthorized: () => router.push("/admin/login"),
-  });
+  } = useAdminBlogEdit(originalSlug, { onUnauthorized: handleUnauthorized });
+
+  const {
+    state: { tags: availableTags },
+  } = useAdminTags({ onUnauthorized: handleUnauthorized });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -87,12 +92,21 @@ export default function EditBlogPage() {
           <label className="mb-2 block text-sm font-bold text-gray-700">
             タグ
           </label>
-          <input
-            className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-            type="text"
-            value={tags}
-            onChange={(e) => setTags(e.target.value)}
-          />
+          <div className="flex flex-wrap gap-2">
+            {availableTags.map((tag) => (
+              <label
+                key={tag.id}
+                className="flex items-center gap-1 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={tags.includes(tag.name)}
+                  onChange={() => toggleTag(tag.name)}
+                />
+                <span>{tag.name}</span>
+              </label>
+            ))}
+          </div>
         </div>
         <div className="mb-6">
           <label className="mb-2 block text-sm font-bold text-gray-700">

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -4,29 +4,34 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAdminBlogList } from "@/app/hooks/admin/useAdminBlogList";
 import { useAdminPortfolioList } from "@/app/hooks/admin/useAdminPortfolioList";
+import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
 import { UnauthorizedError } from "@/app/types/errors";
 import AdminBlogTab from "@/app/admin/AdminBlogTab";
 import AdminPortfolioTab from "@/app/admin/AdminPortfolioTab";
+import AdminTagTab from "@/app/admin/AdminTagTab";
 
-type Tab = "blog" | "portfolio";
+type Tab = "blog" | "portfolio" | "tag";
 
 export default function AdminDashboard() {
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<Tab>("blog");
 
+  const handleUnauthorized = () => router.push("/admin/login");
+
   const {
     state: { blogs, isLoading: blogLoading },
     actions: { deleteBlog },
-  } = useAdminBlogList({
-    onUnauthorized: () => router.push("/admin/login"),
-  });
+  } = useAdminBlogList({ onUnauthorized: handleUnauthorized });
 
   const {
     state: { portfolios, isLoading: portfolioLoading },
     actions: { deletePortfolio },
-  } = useAdminPortfolioList({
-    onUnauthorized: () => router.push("/admin/login"),
-  });
+  } = useAdminPortfolioList({ onUnauthorized: handleUnauthorized });
+
+  const {
+    state: { tags, isLoading: tagLoading },
+    actions: { createTag, updateTag, deleteTag },
+  } = useAdminTags({ onUnauthorized: handleUnauthorized });
 
   const handleDeleteBlog = async (slug: string) => {
     if (!confirm("Are you sure you want to delete this blog?")) return;
@@ -58,6 +63,47 @@ export default function AdminDashboard() {
     }
   };
 
+  const handleCreateTag = async (name: string) => {
+    try {
+      await createTag(name);
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        router.push("/admin/login");
+      } else {
+        alert("Failed to create tag");
+      }
+      console.error("Failed to create tag", error);
+    }
+  };
+
+  const handleUpdateTag = async (id: number, name: string) => {
+    try {
+      await updateTag(id, name);
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        router.push("/admin/login");
+      } else {
+        alert("Failed to update tag");
+      }
+      console.error("Failed to update tag", error);
+    }
+  };
+
+  const handleDeleteTag = async (id: number) => {
+    if (!confirm("このタグを削除しますか？")) return;
+
+    try {
+      await deleteTag(id);
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        router.push("/admin/login");
+      } else {
+        alert("Failed to delete tag");
+      }
+      console.error("Failed to delete tag", error);
+    }
+  };
+
   return (
     <div className="container mx-auto p-8">
       <h1 className="mb-6 text-3xl font-bold">Admin Dashboard</h1>
@@ -83,6 +129,16 @@ export default function AdminDashboard() {
         >
           Portfolio
         </button>
+        <button
+          className={`px-6 py-2 font-semibold ${
+            activeTab === "tag"
+              ? "border-b-2 border-blue-500 text-blue-500"
+              : "text-gray-500 hover:text-gray-700"
+          }`}
+          onClick={() => setActiveTab("tag")}
+        >
+          Tag
+        </button>
       </div>
 
       {activeTab === "blog" && (
@@ -98,6 +154,16 @@ export default function AdminDashboard() {
           portfolios={portfolios}
           isLoading={portfolioLoading}
           onDelete={handleDeletePortfolio}
+        />
+      )}
+
+      {activeTab === "tag" && (
+        <AdminTagTab
+          tags={tags}
+          isLoading={tagLoading}
+          onCreate={handleCreateTag}
+          onUpdate={handleUpdateTag}
+          onDelete={handleDeleteTag}
         />
       )}
     </div>

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -18,6 +18,22 @@ export default function AdminDashboard() {
 
   const handleUnauthorized = () => router.push("/admin/login");
 
+  const withAdminAction = async (
+    fn: () => Promise<void>,
+    errorMessage: string,
+  ) => {
+    try {
+      await fn();
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        handleUnauthorized();
+      } else {
+        alert(errorMessage);
+      }
+      console.error(errorMessage, error);
+    }
+  };
+
   const {
     state: { blogs, isLoading: blogLoading },
     actions: { deleteBlog },
@@ -35,73 +51,28 @@ export default function AdminDashboard() {
 
   const handleDeleteBlog = async (slug: string) => {
     if (!confirm("Are you sure you want to delete this blog?")) return;
-
-    try {
-      await deleteBlog(slug);
-    } catch (error) {
-      if (error instanceof UnauthorizedError) {
-        router.push("/admin/login");
-      } else {
-        alert("Failed to delete blog");
-      }
-      console.error("Failed to delete blog", error);
-    }
+    await withAdminAction(() => deleteBlog(slug), "Failed to delete blog");
   };
 
   const handleDeletePortfolio = async (slug: string) => {
     if (!confirm("Are you sure you want to delete this portfolio?")) return;
-
-    try {
-      await deletePortfolio(slug);
-    } catch (error) {
-      if (error instanceof UnauthorizedError) {
-        router.push("/admin/login");
-      } else {
-        alert("Failed to delete portfolio");
-      }
-      console.error("Failed to delete portfolio", error);
-    }
+    await withAdminAction(
+      () => deletePortfolio(slug),
+      "Failed to delete portfolio",
+    );
   };
 
   const handleCreateTag = async (name: string) => {
-    try {
-      await createTag(name);
-    } catch (error) {
-      if (error instanceof UnauthorizedError) {
-        router.push("/admin/login");
-      } else {
-        alert("Failed to create tag");
-      }
-      console.error("Failed to create tag", error);
-    }
+    await withAdminAction(() => createTag(name), "Failed to create tag");
   };
 
   const handleUpdateTag = async (id: number, name: string) => {
-    try {
-      await updateTag(id, name);
-    } catch (error) {
-      if (error instanceof UnauthorizedError) {
-        router.push("/admin/login");
-      } else {
-        alert("Failed to update tag");
-      }
-      console.error("Failed to update tag", error);
-    }
+    await withAdminAction(() => updateTag(id, name), "Failed to update tag");
   };
 
   const handleDeleteTag = async (id: number) => {
     if (!confirm("このタグを削除しますか？")) return;
-
-    try {
-      await deleteTag(id);
-    } catch (error) {
-      if (error instanceof UnauthorizedError) {
-        router.push("/admin/login");
-      } else {
-        alert("Failed to delete tag");
-      }
-      console.error("Failed to delete tag", error);
-    }
+    await withAdminAction(() => deleteTag(id), "Failed to delete tag");
   };
 
   return (

--- a/frontend/src/app/data/tagData.ts
+++ b/frontend/src/app/data/tagData.ts
@@ -1,9 +1,0 @@
-export const TAGS = [
-  "雑記",
-  "技術",
-  "Android",
-  "WEB",
-  "フロントエンド",
-  "バックエンド",
-] as const;
-export type Tag = (typeof TAGS)[number];

--- a/frontend/src/app/hooks/admin/useAdminBlogCreate.ts
+++ b/frontend/src/app/hooks/admin/useAdminBlogCreate.ts
@@ -10,11 +10,17 @@ export function useAdminBlogCreate() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
-  const [tags, setTags] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
   const [date, setDate] = useState(getTodayInputDate());
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>("");
+
+  const toggleTag = useCallback((tag: string) => {
+    setTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }, []);
 
   const submitCreate = useCallback(async () => {
     setIsLoading(true);
@@ -24,10 +30,7 @@ export function useAdminBlogCreate() {
       title,
       description,
       content,
-      tags: tags
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean),
+      tags,
       date: toJaLongDateFromInput(date),
     };
 
@@ -50,7 +53,7 @@ export function useAdminBlogCreate() {
       content,
       setContent,
       tags,
-      setTags,
+      toggleTag,
       date,
       setDate,
     },

--- a/frontend/src/app/hooks/admin/useAdminBlogEdit.ts
+++ b/frontend/src/app/hooks/admin/useAdminBlogEdit.ts
@@ -14,7 +14,7 @@ export function useAdminBlogEdit(
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
-  const [tags, setTags] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
   const [date, setDate] = useState("");
 
   const [isLoading, setIsLoading] = useState(false);
@@ -38,7 +38,7 @@ export function useAdminBlogEdit(
         setTitle(data.title);
         setDescription(data.description);
         setContent(data.content);
-        setTags((data.tags || []).join(", "));
+        setTags(data.tags || []);
         setDate(toInputDateStringFromJaDate(data.date));
       } catch (e) {
         if (cancelled) return;
@@ -48,7 +48,6 @@ export function useAdminBlogEdit(
         }
         setError(e instanceof Error ? e.message : "Failed to fetch blog");
       } finally {
-        // finally内のreturnはTS警告になるので避ける
         if (!cancelled) {
           setIsLoading(false);
         }
@@ -61,15 +60,18 @@ export function useAdminBlogEdit(
     };
   }, [originalSlug]);
 
+  const toggleTag = useCallback((tag: string) => {
+    setTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }, []);
+
   const buildPayload = useCallback((): BlogUpsertInput => {
     return {
       title,
       description,
       content,
-      tags: tags
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean),
+      tags,
       date: toJaLongDateFromInput(date),
     };
   }, [title, description, content, tags, date]);
@@ -99,7 +101,7 @@ export function useAdminBlogEdit(
       content,
       setContent,
       tags,
-      setTags,
+      toggleTag,
       date,
       setDate,
     },

--- a/frontend/src/app/hooks/admin/useAdminTags.ts
+++ b/frontend/src/app/hooks/admin/useAdminTags.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  adminTagRepository,
+  type Tag,
+} from "@/app/repository/adminTagRepository";
+import { UnauthorizedError } from "@/app/types/errors";
+
+export function useAdminTags({
+  onUnauthorized,
+}: { onUnauthorized?: () => void } = {}) {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>("");
+
+  const onUnauthorizedRef = useRef(onUnauthorized);
+  useEffect(() => {
+    onUnauthorizedRef.current = onUnauthorized;
+  }, [onUnauthorized]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchTags = async () => {
+      setIsLoading(true);
+      setError("");
+      try {
+        const data = await adminTagRepository.list();
+        if (!cancelled) setTags(data);
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof UnauthorizedError) {
+          onUnauthorizedRef.current?.();
+          return;
+        }
+        setError(e instanceof Error ? e.message : "Failed to fetch tags");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    fetchTags();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const createTag = useCallback(async (name: string) => {
+    const created = await adminTagRepository.create(name);
+    setTags((prev) =>
+      [...prev, created].sort((a, b) => a.name.localeCompare(b.name)),
+    );
+  }, []);
+
+  const updateTag = useCallback(async (id: number, name: string) => {
+    const updated = await adminTagRepository.update(id, name);
+    setTags((prev) =>
+      prev
+        .map((t) => (t.id === id ? updated : t))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    );
+  }, []);
+
+  const deleteTag = useCallback(async (id: number) => {
+    await adminTagRepository.delete(id);
+    setTags((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return {
+    state: { tags, isLoading, error },
+    actions: { createTag, updateTag, deleteTag },
+  };
+}

--- a/frontend/src/app/hooks/blog/useBlogSearchContext.tsx
+++ b/frontend/src/app/hooks/blog/useBlogSearchContext.tsx
@@ -5,16 +5,18 @@ import {
   useContext,
   useState,
   useCallback,
+  useEffect,
   ReactNode,
 } from "react";
-import { Tag } from "@/app/data/tagData";
+import { tagRepository } from "@/app/repository/tagRepository";
 
 interface BlogSearchContextType {
-  selectedTags: Tag[];
+  availableTags: string[];
+  selectedTags: string[];
   keyword: string;
-  setSelectedTags: (tags: Tag[]) => void;
+  setSelectedTags: (tags: string[]) => void;
   setKeyword: (keyword: string) => void;
-  toggleTag: (tag: Tag) => void;
+  toggleTag: (tag: string) => void;
 }
 
 const BlogSearchContext = createContext<BlogSearchContextType | undefined>(
@@ -22,10 +24,17 @@ const BlogSearchContext = createContext<BlogSearchContextType | undefined>(
 );
 
 export function BlogSearchProvider({ children }: { children: ReactNode }) {
-  const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
+  const [availableTags, setAvailableTags] = useState<string[]>([]);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [keyword, setKeyword] = useState<string>("");
 
-  const toggleTag = useCallback((tag: Tag) => {
+  useEffect(() => {
+    tagRepository
+      .getAll()
+      .then((tags) => setAvailableTags(tags.map((t) => t.name)));
+  }, []);
+
+  const toggleTag = useCallback((tag: string) => {
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
     );
@@ -34,6 +43,7 @@ export function BlogSearchProvider({ children }: { children: ReactNode }) {
   return (
     <BlogSearchContext.Provider
       value={{
+        availableTags,
         selectedTags,
         keyword,
         setSelectedTags,

--- a/frontend/src/app/repository/adminTagRepository.ts
+++ b/frontend/src/app/repository/adminTagRepository.ts
@@ -1,0 +1,36 @@
+import { fetchJsonOrThrow, requestOrThrow } from "@/app/network/adminApi";
+
+export type Tag = {
+  id: number;
+  name: string;
+};
+
+class AdminTagRepository {
+  async list(): Promise<Tag[]> {
+    return await fetchJsonOrThrow<Tag[]>("/api/tags");
+  }
+
+  async create(name: string): Promise<Tag> {
+    const res = await requestOrThrow("/api/tags", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+    return (await res.json()) as Tag;
+  }
+
+  async update(id: number, name: string): Promise<Tag> {
+    const res = await requestOrThrow(`/api/tags/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+    return (await res.json()) as Tag;
+  }
+
+  async delete(id: number): Promise<void> {
+    await requestOrThrow(`/api/tags/${id}`, { method: "DELETE" });
+  }
+}
+
+export const adminTagRepository = new AdminTagRepository();

--- a/frontend/src/app/repository/tagRepository.ts
+++ b/frontend/src/app/repository/tagRepository.ts
@@ -1,0 +1,15 @@
+import { API_BASE_URL, fetchJsonOrNull } from "@/app/network/publicApi";
+
+export type Tag = {
+  id: number;
+  name: string;
+};
+
+class TagRepository {
+  async getAll(): Promise<Tag[]> {
+    const tags = await fetchJsonOrNull<Tag[]>(`${API_BASE_URL}/api/tags`);
+    return tags || [];
+  }
+}
+
+export const tagRepository = new TagRepository();

--- a/frontend/src/app/ui/blog/section/TagSearchSection.tsx
+++ b/frontend/src/app/ui/blog/section/TagSearchSection.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useBlogSearchContext } from "@/app/hooks/blog/useBlogSearchContext";
-import { TAGS } from "@/app/data/tagData";
 
 export default function TagSearchSection() {
-  const { selectedTags, toggleTag, setSelectedTags } = useBlogSearchContext();
+  const { availableTags, selectedTags, toggleTag, setSelectedTags } =
+    useBlogSearchContext();
 
   const handleClearTags = () => {
     setSelectedTags([]);
@@ -28,7 +28,7 @@ export default function TagSearchSection() {
           )}
         </div>
         <div className="flex flex-wrap gap-2">
-          {TAGS.map((tag) => (
+          {availableTags.map((tag) => (
             <button
               key={tag}
               onClick={() => toggleTag(tag)}


### PR DESCRIPTION
## 変更内容
- 表題の通り
- adminにタグ用の画面を追加
- TagTableでタグスキーマを切り出し
- 既存のCRUDと同様にしてタグ用のAPIを実装

## 該当するissue

<!-- もしあれば -->

- close #93 