### PR TITLE
[Frontend] ハンバーガーメニューとヘッダー固定を追加

### DIFF
--- a/frontend/src/app/components/header.tsx
+++ b/frontend/src/app/components/header.tsx
@@ -87,14 +87,14 @@ export default function Header() {
       {/* Overlay */}
       {isOpen && (
         <div
-          className="md:hidden fixed inset-0 bg-black/30 z-overlay pointer-events-auto"
+          className="md:hidden fixed inset-0 bg-black/30 z-overlay"
           onClick={closeMenu}
         />
       )}
 
       {/* Side drawer */}
       <div
-        className={`md:hidden fixed top-0 right-0 h-full w-64 bg-gray-200/70 backdrop-blur-sm z-drawer transform transition-transform duration-300 pointer-events-auto ${isOpen ? "translate-x-0" : "translate-x-full"}`}
+        className={`md:hidden fixed top-0 right-0 h-full w-64 bg-gray-200/70 backdrop-blur-sm z-drawer transform transition-transform duration-300 ${isOpen ? "translate-x-0" : "translate-x-full"}`}
       >
         {/* Close button */}
         <div className="flex justify-end px-4 py-4">

--- a/frontend/src/app/components/header.tsx
+++ b/frontend/src/app/components/header.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+"use client";
+
+import React, { useState } from "react";
 import Link from "next/link";
 import { ROUTES } from "@/app/routes";
 
@@ -14,14 +16,17 @@ const animatedUnderline = `
 `;
 
 export default function Header() {
+  const [isOpen, setIsOpen] = useState(false);
+
   const navItems = [
+    { id: "home", link: ROUTES.HOME, label: "ホーム" },
     { id: "profile", link: ROUTES.PROFILE, label: "プロフィール" },
     { id: "blog", link: ROUTES.BLOG, label: "ブログ" },
     { id: "portfolio", link: ROUTES.PORTFOLIO, label: "ポートフォリオ" },
   ];
 
   return (
-    <header className="w-full border-b border-gray-200 bg-gray-200 font-sans">
+    <header className="sticky top-0 w-full border-b border-gray-200 bg-gray-200 font-sans z-30">
       <div className="max-w-4xl w-full mx-auto px-4 py-4 flex items-center justify-between">
         <Link
           href={ROUTES.HOME}
@@ -29,7 +34,7 @@ export default function Header() {
         >
           kyo1941
         </Link>
-        <nav>
+        <nav className="hidden md:flex">
           <ul className="flex gap-8 text-base font-semibold">
             {navItems.map((item) => (
               <li key={item.id}>
@@ -43,6 +48,59 @@ export default function Header() {
             ))}
           </ul>
         </nav>
+        {/* Hamburger button (open only) */}
+        <button
+          className="md:hidden flex flex-col justify-center gap-1.5 w-8 h-8"
+          onClick={() => setIsOpen(true)}
+          aria-label="メニューを開く"
+          aria-expanded={isOpen}
+        >
+          <span className="block h-0.5 w-full bg-gray-900" />
+          <span className="block h-0.5 w-full bg-gray-900" />
+          <span className="block h-0.5 w-full bg-gray-900" />
+        </button>
+      </div>
+
+      {/* Overlay */}
+      {isOpen && (
+        <div
+          className="md:hidden fixed inset-0 bg-black/30 z-40"
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+
+      {/* Side drawer */}
+      <div
+        className={`md:hidden fixed top-0 right-0 h-full w-64 bg-gray-200/70 backdrop-blur-sm z-50 transform transition-transform duration-300 ${isOpen ? "translate-x-0" : "translate-x-full"}`}
+      >
+        {/* Close button */}
+        <div className="flex justify-end px-4 py-4">
+          <button
+            onClick={() => setIsOpen(false)}
+            aria-label="メニューを閉じる"
+            className="flex flex-col justify-center gap-1.5 w-8 h-8"
+          >
+            <span className="block h-0.5 w-full bg-gray-900 rotate-45 translate-y-2" />
+            <span className="block h-0.5 w-full bg-gray-900 opacity-0" />
+            <span className="block h-0.5 w-full bg-gray-900 -rotate-45 -translate-y-2" />
+          </button>
+        </div>
+        <ul className="flex flex-col">
+          {navItems.map((item) => (
+            <li
+              key={item.id}
+              className="mx-6 border-b border-gray-400 last:border-b-0"
+            >
+              <Link
+                href={item.link}
+                onClick={() => setIsOpen(false)}
+                className="block -mx-6 px-6 py-4 no-underline text-inherit text-base font-semibold"
+              >
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
     </header>
   );

--- a/frontend/src/app/components/header.tsx
+++ b/frontend/src/app/components/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { ROUTES } from "@/app/routes";
 
@@ -15,15 +15,38 @@ const animatedUnderline = `
   hover:after:w-full focus-visible:after:w-full
 `;
 
+const navItems = [
+  { id: "home", link: ROUTES.HOME, label: "ホーム" },
+  { id: "profile", link: ROUTES.PROFILE, label: "プロフィール" },
+  { id: "blog", link: ROUTES.BLOG, label: "ブログ" },
+  { id: "portfolio", link: ROUTES.PORTFOLIO, label: "ポートフォリオ" },
+];
+
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
 
-  const navItems = [
-    { id: "home", link: ROUTES.HOME, label: "ホーム" },
-    { id: "profile", link: ROUTES.PROFILE, label: "プロフィール" },
-    { id: "blog", link: ROUTES.BLOG, label: "ブログ" },
-    { id: "portfolio", link: ROUTES.PORTFOLIO, label: "ポートフォリオ" },
-  ];
+  const closeMenu = () => setIsOpen(false);
+
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? "hidden" : "auto";
+
+    // Disable interactions on main content when drawer is open
+    const mainContent = document.getElementById("main-content");
+    if (mainContent) {
+      if (isOpen) {
+        mainContent.style.pointerEvents = "none";
+      } else {
+        mainContent.style.pointerEvents = "auto";
+      }
+    }
+
+    return () => {
+      document.body.style.overflow = "auto";
+      if (mainContent) {
+        mainContent.style.pointerEvents = "auto";
+      }
+    };
+  }, [isOpen]);
 
   return (
     <header className="sticky top-0 w-full border-b border-gray-200 bg-gray-200 font-sans z-30">
@@ -64,19 +87,19 @@ export default function Header() {
       {/* Overlay */}
       {isOpen && (
         <div
-          className="md:hidden fixed inset-0 bg-black/30 z-40"
-          onClick={() => setIsOpen(false)}
+          className="md:hidden fixed inset-0 bg-black/30 z-overlay pointer-events-auto"
+          onClick={closeMenu}
         />
       )}
 
       {/* Side drawer */}
       <div
-        className={`md:hidden fixed top-0 right-0 h-full w-64 bg-gray-200/70 backdrop-blur-sm z-50 transform transition-transform duration-300 ${isOpen ? "translate-x-0" : "translate-x-full"}`}
+        className={`md:hidden fixed top-0 right-0 h-full w-64 bg-gray-200/70 backdrop-blur-sm z-drawer transform transition-transform duration-300 pointer-events-auto ${isOpen ? "translate-x-0" : "translate-x-full"}`}
       >
         {/* Close button */}
         <div className="flex justify-end px-4 py-4">
           <button
-            onClick={() => setIsOpen(false)}
+            onClick={closeMenu}
             aria-label="メニューを閉じる"
             className="flex flex-col justify-center gap-1.5 w-8 h-8"
           >
@@ -93,7 +116,7 @@ export default function Header() {
             >
               <Link
                 href={item.link}
-                onClick={() => setIsOpen(false)}
+                onClick={closeMenu}
                 className="block -mx-6 px-6 py-4 no-underline text-inherit text-base font-semibold"
               >
                 {item.label}

--- a/frontend/src/app/ui/blog/[slug]/page.tsx
+++ b/frontend/src/app/ui/blog/[slug]/page.tsx
@@ -28,7 +28,7 @@ export default async function PostPage({
     return (
       <div className="min-h-screen bg-gray-50 font-sans">
         <Header />
-        <main className="max-w-4xl mx-auto px-4 py-12">
+        <main id="main-content" className="max-w-4xl mx-auto px-4 py-12">
           <div className="bg-white rounded-lg shadow-sm p-8">
             <div className="mb-8">
               <BackButton fallbackPath={ROUTES.BLOG} />

--- a/frontend/src/app/ui/blog/page.tsx
+++ b/frontend/src/app/ui/blog/page.tsx
@@ -8,7 +8,7 @@ export default function BlogPage() {
   return (
     <div className="min-h-screen bg-gray-50 font-sans">
       <Header />
-      <main className="max-w-4xl mx-auto px-4 py-12">
+      <main id="main-content" className="max-w-4xl mx-auto px-4 py-12">
         <div className="bg-white rounded-lg shadow-sm p-8">
           <h1 className="text-4xl font-bold mb-8 text-gray-900">ブログ</h1>
 

--- a/frontend/src/app/ui/portfolio/[slug]/page.tsx
+++ b/frontend/src/app/ui/portfolio/[slug]/page.tsx
@@ -28,7 +28,7 @@ export default async function PortfolioDetailPage({
     return (
       <div className="min-h-screen bg-gray-50 font-sans">
         <Header />
-        <main className="max-w-4xl mx-auto px-4 py-12">
+        <main id="main-content" className="max-w-4xl mx-auto px-4 py-12">
           <div className="bg-white rounded-lg shadow-sm p-8">
             <div className="mb-8">
               <BackButton fallbackPath={ROUTES.PORTFOLIO} />
@@ -47,7 +47,7 @@ export default async function PortfolioDetailPage({
   return (
     <div className="min-h-screen bg-gray-50 font-sans">
       <Header />
-      <main className="max-w-4xl mx-auto px-4 py-12">
+      <main id="main-content" className="max-w-4xl mx-auto px-4 py-12">
         <div className="bg-white rounded-lg shadow-sm p-8">
           <div className="mb-8">
             <BackButton fallbackPath={ROUTES.PORTFOLIO} />

--- a/frontend/src/app/ui/portfolio/page.tsx
+++ b/frontend/src/app/ui/portfolio/page.tsx
@@ -5,7 +5,7 @@ export default function PortfolioPage() {
   return (
     <div className="min-h-screen bg-gray-50 font-sans">
       <Header />
-      <main className="max-w-4xl mx-auto px-4 py-12">
+      <main id="main-content" className="max-w-4xl mx-auto px-4 py-12">
         <div className="bg-white rounded-lg shadow-sm p-8">
           <h1 className="text-4xl font-bold mb-8 text-gray-900">
             ポートフォリオ

--- a/frontend/src/app/ui/profile/page.tsx
+++ b/frontend/src/app/ui/profile/page.tsx
@@ -8,7 +8,7 @@ export default function AboutPage() {
     <div className="min-h-screen bg-gray-50 font-sans">
       <Header />
 
-      <main className="max-w-4xl mx-auto px-4 py-12">
+      <main id="main-content" className="max-w-4xl mx-auto px-4 py-12">
         <div className="bg-white rounded-lg shadow-sm p-8">
           <h1 className="text-4xl font-bold mb-8 text-gray-900">
             プロフィール

--- a/frontend/src/app/ui/top/page.tsx
+++ b/frontend/src/app/ui/top/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-gray-50 font-sans">
       <Header />
-      <main className="max-w-4xl mx-auto px-4 py-12">
+      <main id="main-content" className="max-w-4xl mx-auto px-4 py-12">
         <div className="bg-white rounded-lg shadow-sm p-8">
           <section className="border-b border-gray-200 mt-12 pb-12 text-center">
             <WelcomeSection />

--- a/frontend/src/app/ui/top/section/WelcomeSection.tsx
+++ b/frontend/src/app/ui/top/section/WelcomeSection.tsx
@@ -54,11 +54,7 @@ export default function WelcomeSection() {
     <div className="h-32 flex flex-col justify-center items-center">
       <h2 className="text-3xl sm:text-5xl font-mono font-bold text-gray-900">
         {displayText}
-        <motion.span
-          animate={{ opacity: [0, 1, 0] }}
-          transition={{ repeat: Infinity, duration: 0.8 }}
-          className="inline-block w-[0.1em] h-[1em] bg-blue-600 ml-1 align-middle"
-        />
+        <span className="inline-block w-[0.1em] h-[1em] bg-blue-600 ml-1 align-middle animate-blink" />
       </h2>
       <motion.p
         initial={{ opacity: 0, y: 20 }}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -28,6 +28,15 @@ const config: Config = {
           "50%": { opacity: "1" },
         },
       },
+      animation: {
+        blink: "blink 0.8s infinite",
+      },
+      keyframes: {
+        blink: {
+          "0%, 100%": { opacity: "0" },
+          "50%": { opacity: "1" },
+        },
+      },
     },
   },
   plugins: [],

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -19,6 +19,15 @@ const config: Config = {
       fontFamily: {
         sans: ["Noto Sans JP", "Helvetica Neue", "Arial", "sans-serif"],
       },
+      animation: {
+        blink: "blink 0.8s infinite",
+      },
+      keyframes: {
+        blink: {
+          "0%, 100%": { opacity: "0" },
+          "50%": { opacity: "1" },
+        },
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 変更内容
- ナビゲーションに「ホーム」リンクを追加
- モバイル幅では右からスライドするドロワーメニューに切り替え（ハンバーガーボタン→ドロワー内バツボタン）
- ヘッダーを sticky に変更し、スクロール時も固定表示

## 該当するissue

<!-- もしあれば -->

- close #107
- close #108