### PR TITLE
[Document] /ship スキルを追加

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ship
+description: Lint check, commit, push, and create a PR following this project's conventions
+disable-model-invocation: true
+allowed-tools: Bash(pnpm *), Bash(git *), Bash(gh *)
+---
+
+実装が完了したら、以下の手順で lint チェック・コミット・プッシュ・PR 作成を行ってください。
+
+## 1. Lint チェック
+
+変更が含まれる領域に応じて実行してください。
+
+- **Frontend** (`frontend/` に変更がある場合): `cd frontend && pnpm lint`
+- **Backend** (`backend/` に変更がある場合): `cd backend && ./gradlew :app:ktlintCheck`
+
+エラーがあれば修正してから次に進む。
+
+## 2. git の現状確認
+
+以下を並列で実行して内容を把握する。
+
+```
+git status
+git diff
+git log --oneline -5
+```
+
+## 3. コミット
+
+- 変更ファイルを個別に `git add` する（`git add -A` は使わない）
+- コミットメッセージは既存のログに倣い `<type>: <summary>` 形式（英語）
+- 末尾に必ず `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` を付ける
+- HEREDOC でメッセージを渡す
+
+## 4. プッシュ
+
+```
+git push -u origin <current-branch>
+```
+
+## 5. PR 作成
+
+### タイトル形式
+
+過去の PR を参考にスコープを `[]` で示す:
+
+- `[Frontend] ...`
+- `[Backend] ...`
+- `[Frontend/Backend] ...`
+- `[Infra] ...`
+
+### ラベル
+
+変更スコープに応じて付与（複数可）: `Frontend`, `Backend`, `Infra`, `Bug`, `Document`
+
+### 本文
+
+`.github/PULL_REQUEST_TEMPLATE.md` のテンプレートに従う:
+
+```
+## 変更内容
+- <箇条書き>
+
+## 該当するissue
+
+<!-- もしあれば -->
+
+- close #<number>
+```
+
+### コマンド例
+
+```
+gh pr create --title "[Frontend] ..." --label "Frontend" --body "$(cat <<'EOF'
+## 変更内容
+- ...
+
+## 該当するissue
+
+- close #...
+EOF
+)"
+```

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -30,8 +30,13 @@ git log --oneline -5
 
 - 変更ファイルを個別に `git add` する（`git add -A` は使わない）
 - コミットメッセージは既存のログに倣い `<type>: <summary>` 形式（英語）
-- 末尾に必ず `Co-Authored-By: Claude Sonnet <version> <noreply@anthropic.com>` を付ける（`<version>` は使用したモデルのバージョンに置き換える）
+- 末尾に必ず `Co-Authored-By: Claude <model> <version> <noreply@anthropic.com>` を付ける（例: `Claude Sonnet 4.6`）
 - HEREDOC でメッセージを渡す
+
+### コミットの粒度
+
+- **1コミット = 1つの論理的な変更単位**。複数の独立した変更は分けてコミットする
+- **各コミットはビルドが通る状態**にしておく。壊れた状態でコミットしない
 
 ## 4. プッシュ
 
@@ -47,8 +52,8 @@ git push -u origin <current-branch>
 
 - `[Frontend] ...`
 - `[Backend] ...`
-- `[Frontend/Backend] ...`
 - `[Infra] ...`
+- 複数領域にまたがる場合は `/` 区切り: `[Frontend/Backend] ...`, `[Frontend/Infra] ...`
 
 ### ラベル
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -30,7 +30,7 @@ git log --oneline -5
 
 - 変更ファイルを個別に `git add` する（`git add -A` は使わない）
 - コミットメッセージは既存のログに倣い `<type>: <summary>` 形式（英語）
-- 末尾に必ず `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` を付ける
+- 末尾に必ず `Co-Authored-By: Claude Sonnet <version> <noreply@anthropic.com>` を付ける（`<version>` は使用したモデルのバージョンに置き換える）
 - HEREDOC でメッセージを渡す
 
 ## 4. プッシュ


### PR DESCRIPTION
## 変更内容
- lint チェック・コミット・プッシュ・PR 作成をまとめて行う `/ship` スキルを追加
- このプロジェクトの PR 規約（タイトル形式・ラベル・テンプレート）をスキル内に記載

## 該当するissue

<!-- もしあれば -->

-