### PR TITLE
fix: remove cache mounts from Dockerfile for Railway compatibility

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,16 +7,14 @@ COPY --chown=gradle:gradle settings.gradle.kts settings.gradle.kts
 COPY --chown=gradle:gradle gradle/libs.versions.toml gradle/libs.versions.toml
 COPY --chown=gradle:gradle app/build.gradle.kts app/build.gradle.kts
 
-RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
-    chmod +x gradlew && ./gradlew --no-daemon assemble -x test
+RUN chmod +x gradlew && ./gradlew --no-daemon assemble -x test
 
 COPY --chown=gradle:gradle . .
 
 # application.yaml はgitignoreされているため、テンプレートからコピーして生成する
 RUN cp app/src/main/resources/application.yaml.template app/src/main/resources/application.yaml
 
-RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
-    ./gradlew --no-daemon buildFatJar -x test
+RUN ./gradlew --no-daemon buildFatJar -x test
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app


### PR DESCRIPTION
## Summary

#114 のキャッシュマウントへの `id` 追加では解決せず、`Cache mount ID is not prefixed with cache key` エラーが発生した。

Railway が要求する形式は `id=s/<service-id>-<identifier>` でサービスIDをハードコードする必要があるため、Dockerfile に Railway 固有の値が混入してしまう。`--mount=type=cache` はビルド最適化であり必須ではないため、削除で対応する。

```diff
- RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
-     chmod +x gradlew && ./gradlew --no-daemon assemble -x test
+ RUN chmod +x gradlew && ./gradlew --no-daemon assemble -x test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)