### PR TITLE
fix: use repo root as Docker build context for Railway compatibility

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,15 @@
 FROM gradle:8.5-jdk21 AS builder
 WORKDIR /home/gradle/src
 
-COPY --chown=gradle:gradle gradle/ gradle/
-COPY --chown=gradle:gradle gradlew gradlew
-COPY --chown=gradle:gradle settings.gradle.kts settings.gradle.kts
-COPY --chown=gradle:gradle gradle/libs.versions.toml gradle/libs.versions.toml
-COPY --chown=gradle:gradle app/build.gradle.kts app/build.gradle.kts
+COPY --chown=gradle:gradle backend/gradle/ gradle/
+COPY --chown=gradle:gradle backend/gradlew gradlew
+COPY --chown=gradle:gradle backend/settings.gradle.kts settings.gradle.kts
+COPY --chown=gradle:gradle backend/gradle/libs.versions.toml gradle/libs.versions.toml
+COPY --chown=gradle:gradle backend/app/build.gradle.kts app/build.gradle.kts
 
 RUN chmod +x gradlew && ./gradlew --no-daemon assemble -x test
 
-COPY --chown=gradle:gradle . .
+COPY --chown=gradle:gradle backend/ .
 
 # application.yaml はgitignoreされているため、テンプレートからコピーして生成する
 RUN cp app/src/main/resources/application.yaml.template app/src/main/resources/application.yaml

--- a/backend/Dockerfile.dockerignore
+++ b/backend/Dockerfile.dockerignore
@@ -1,0 +1,19 @@
+# バックエンドビルド用 .dockerignore（ビルドコンテキスト: リポジトリルート）
+
+# バックエンド以外は不要
+frontend/
+nginx/
+
+# Gradleビルド成果物
+backend/.gradle
+backend/build
+backend/**/build/
+
+# IDE・OS
+.idea/
+.DS_Store
+**/*.iml
+
+# 秘匿ファイル（テンプレートからDockerfile内でコピーするため除外）
+backend/**/application.yaml
+.env

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,8 @@
 services:
   backend:
-    build: ./backend
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     ports:
       - "8080:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   backend:
-    build: ./backend
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Summary

Railway はリポジトリルートをビルドコンテキストとして使用するため、`backend/` を前提に書かれた COPY コマンドが失敗していた。

**変更内容:**
- `backend/Dockerfile`: 全 COPY ソースパスに `backend/` プレフィックスを追加
- `docker-compose.yml`, `docker-compose.prod.yml`: `build: ./backend` → `context: . / dockerfile: backend/Dockerfile` に変更（Railway と統一）
- `backend/Dockerfile.dockerignore`: リポジトリルートをコンテキストとした際の除外設定を追加（BuildKit が `<dockerfile>.dockerignore` を自動適用）

## 経緯

- #114: `--mount=type=cache` に `id` 追加 → Railway が `id=s/<service-id>-<identifier>` 形式を要求するため NG
- Railway のキャッシュマウント制約を回避するためキャッシュマウントを削除したが、ビルドコンテキストの問題が顕在化

🤖 Generated with [Claude Code](https://claude.com/claude-code)