### PR TITLE
fix: use Next.js API route for login to fix cross-origin cookie issue

### DIFF
--- a/backend/app/src/main/kotlin/my/backend/routes/AuthRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/AuthRoutes.kt
@@ -19,18 +19,7 @@ fun Route.authRoutes(authService: AuthService) {
                 val token = authService.authenticate(loginRequest.username, loginRequest.password)
 
                 if (token != null) {
-                    call.response.cookies.append(
-                        Cookie(
-                            name = "auth_token",
-                            value = token,
-                            httpOnly = true,
-                            secure = System.getenv("KTOR_ENV") == "production",
-                            path = "/",
-                            maxAge = 3600,
-                            extensions = mapOf("SameSite" to "Strict"),
-                        ),
-                    )
-                    call.respond(HttpStatusCode.OK)
+                    call.respond(HttpStatusCode.OK, mapOf("token" to token))
                 } else {
                     call.respond(HttpStatusCode.Unauthorized, "Invalid credentials")
                 }

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
+
+const IS_PRODUCTION = process.env.NODE_ENV === "production";
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  const backendRes = await fetch(`${API_BASE_URL}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!backendRes.ok) {
+    const text = await backendRes.text();
+    return new NextResponse(text || "Invalid credentials", {
+      status: backendRes.status,
+    });
+  }
+
+  const { token } = await backendRes.json();
+
+  const response = NextResponse.json({ ok: true }, { status: 200 });
+  response.cookies.set("auth_token", token, {
+    httpOnly: true,
+    secure: IS_PRODUCTION,
+    sameSite: "strict",
+    path: "/",
+    maxAge: 3600,
+  });
+
+  return response;
+}

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -6,31 +6,41 @@ const API_BASE_URL =
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
+  try {
+    const body = await request.json();
 
-  const backendRes = await fetch(`${API_BASE_URL}/api/auth/login`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-
-  if (!backendRes.ok) {
-    const text = await backendRes.text();
-    return new NextResponse(text || "Invalid credentials", {
-      status: backendRes.status,
+    const backendRes = await fetch(`${API_BASE_URL}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
     });
+
+    if (!backendRes.ok) {
+      const text = await backendRes.text();
+      return new NextResponse(text || "Invalid credentials", {
+        status: backendRes.status,
+      });
+    }
+
+    const { token } = await backendRes.json();
+
+    if (typeof token !== "string") {
+      console.error("Token is missing or not a string in the backend response");
+      return new NextResponse("Internal Server Error", { status: 500 });
+    }
+
+    const response = NextResponse.json({ ok: true }, { status: 200 });
+    response.cookies.set("auth_token", token, {
+      httpOnly: true,
+      secure: IS_PRODUCTION,
+      sameSite: "strict",
+      path: "/",
+      maxAge: 3600,
+    });
+
+    return response;
+  } catch (error) {
+    console.error("Login API route error:", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
   }
-
-  const { token } = await backendRes.json();
-
-  const response = NextResponse.json({ ok: true }, { status: 200 });
-  response.cookies.set("auth_token", token, {
-    httpOnly: true,
-    secure: IS_PRODUCTION,
-    sameSite: "strict",
-    path: "/",
-    maxAge: 3600,
-  });
-
-  return response;
 }

--- a/frontend/src/app/repository/authRepository.ts
+++ b/frontend/src/app/repository/authRepository.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL, requestOrThrow } from "@/app/network/publicApi";
+import { requestOrThrow } from "@/app/network/publicApi";
 
 export type LoginInput = {
   username: string;
@@ -7,11 +7,10 @@ export type LoginInput = {
 
 export class AuthRepository {
   async login(input: LoginInput): Promise<void> {
-    await requestOrThrow(`${API_BASE_URL}/api/auth/login`, {
+    await requestOrThrow("/api/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input),
-      credentials: "include",
     });
   }
 }


### PR DESCRIPTION
## Summary
- バックエンドがトークンをレスポンスボディで返すように変更
- Next.js API Route (`/api/auth/login`) を新規作成し、バックエンドへの中継とクッキーのセットを担当
- `authRepository.ts` のログインエンドポイントを Next.js API Route に変更

## 背景
フロントエンド（`kyo1941.com`）とバックエンド（`railway.app`）が別ドメインのため、バックエンドが `SameSite=Strict` でセットした Cookie がフロントエンドに渡らず、ログイン後のリダイレクトが機能しなかった。

Next.js API Route を中継にすることで、Cookie をフロントエンドドメイン（`kyo1941.com`）にセットできるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)