### PR TITLE
fix: proxy admin API calls through Next.js to forward auth cookie

### DIFF
--- a/frontend/src/app/api/admin/[...path]/route.ts
+++ b/frontend/src/app/api/admin/[...path]/route.ts
@@ -1,0 +1,79 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
+
+async function proxyAdmin(
+  request: NextRequest,
+  path: string[],
+): Promise<NextResponse> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get("auth_token")?.value;
+
+    const backendUrl = new URL(`/api/admin/${path.join("/")}`, BACKEND_URL);
+    request.nextUrl.searchParams.forEach((value, key) => {
+      backendUrl.searchParams.set(key, value);
+    });
+
+    const forwardHeaders: HeadersInit = {};
+
+    const contentType = request.headers.get("content-type");
+    if (contentType) forwardHeaders["Content-Type"] = contentType;
+
+    if (token) forwardHeaders["Cookie"] = `auth_token=${token}`;
+
+    const origin = request.headers.get("origin");
+    if (origin) forwardHeaders["Origin"] = origin;
+
+    const hasBody = request.method !== "GET" && request.method !== "HEAD";
+    const body = hasBody ? await request.text() : undefined;
+
+    const backendRes = await fetch(backendUrl.toString(), {
+      method: request.method,
+      headers: forwardHeaders,
+      body,
+    });
+
+    const resBody = await backendRes.text();
+    const resContentType =
+      backendRes.headers.get("content-type") ?? "application/json";
+
+    return new NextResponse(resBody || null, {
+      status: backendRes.status,
+      headers: { "Content-Type": resContentType },
+    });
+  } catch (error) {
+    console.error("Admin proxy error:", error);
+    return new NextResponse("Internal Server Error", { status: 500 });
+  }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyAdmin(request, (await params).path);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyAdmin(request, (await params).path);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyAdmin(request, (await params).path);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyAdmin(request, (await params).path);
+}

--- a/frontend/src/app/network/adminApi.ts
+++ b/frontend/src/app/network/adminApi.ts
@@ -1,6 +1,8 @@
 import { ApiError, NotFoundError, UnauthorizedError } from "@/app/types/errors";
 export { API_BASE_URL } from "@/app/network/publicApi";
 
+export const ADMIN_API_BASE = "/api/admin";
+
 export async function requestOrThrow(
   input: RequestInfo | URL,
   init?: RequestInit,

--- a/frontend/src/app/repository/adminBlogRepository.ts
+++ b/frontend/src/app/repository/adminBlogRepository.ts
@@ -7,12 +7,13 @@ import {
   requestOrThrow,
   fetchJsonOrThrow,
   API_BASE_URL,
+  ADMIN_API_BASE,
 } from "@/app/network/adminApi";
 
 class AdminBlogRepository {
   async list(): Promise<AdminBlogListItem[]> {
     return await fetchJsonOrThrow<AdminBlogListItem[]>(
-      `${API_BASE_URL}/api/admin/blogs`,
+      `${ADMIN_API_BASE}/blogs`,
     );
   }
 
@@ -23,7 +24,7 @@ class AdminBlogRepository {
   }
 
   async create(input: BlogUpsertInput): Promise<void> {
-    await requestOrThrow(`${API_BASE_URL}/api/admin/blogs`, {
+    await requestOrThrow(`${ADMIN_API_BASE}/blogs`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input),
@@ -32,7 +33,7 @@ class AdminBlogRepository {
 
   async update(originalSlug: string, input: BlogUpsertInput): Promise<void> {
     await requestOrThrow(
-      `${API_BASE_URL}/api/admin/blogs/${encodeURIComponent(originalSlug)}`,
+      `${ADMIN_API_BASE}/blogs/${encodeURIComponent(originalSlug)}`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -43,7 +44,7 @@ class AdminBlogRepository {
 
   async delete(slug: string): Promise<void> {
     await requestOrThrow(
-      `${API_BASE_URL}/api/admin/blogs/${encodeURIComponent(slug)}`,
+      `${ADMIN_API_BASE}/blogs/${encodeURIComponent(slug)}`,
       {
         method: "DELETE",
       },

--- a/frontend/src/app/repository/adminPortfolioRepository.ts
+++ b/frontend/src/app/repository/adminPortfolioRepository.ts
@@ -7,12 +7,13 @@ import {
   requestOrThrow,
   fetchJsonOrThrow,
   API_BASE_URL,
+  ADMIN_API_BASE,
 } from "@/app/network/adminApi";
 
 class AdminPortfolioRepository {
   async list(): Promise<AdminPortfolioListItem[]> {
     return await fetchJsonOrThrow<AdminPortfolioListItem[]>(
-      `${API_BASE_URL}/api/admin/portfolios`,
+      `${ADMIN_API_BASE}/portfolios`,
     );
   }
 
@@ -23,7 +24,7 @@ class AdminPortfolioRepository {
   }
 
   async create(input: PortfolioUpsertInput): Promise<void> {
-    await requestOrThrow(`${API_BASE_URL}/api/admin/portfolios`, {
+    await requestOrThrow(`${ADMIN_API_BASE}/portfolios`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input),
@@ -35,7 +36,7 @@ class AdminPortfolioRepository {
     input: PortfolioUpsertInput,
   ): Promise<void> {
     await requestOrThrow(
-      `${API_BASE_URL}/api/admin/portfolios/${encodeURIComponent(originalSlug)}`,
+      `${ADMIN_API_BASE}/portfolios/${encodeURIComponent(originalSlug)}`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -46,7 +47,7 @@ class AdminPortfolioRepository {
 
   async delete(slug: string): Promise<void> {
     await requestOrThrow(
-      `${API_BASE_URL}/api/admin/portfolios/${encodeURIComponent(slug)}`,
+      `${ADMIN_API_BASE}/portfolios/${encodeURIComponent(slug)}`,
       {
         method: "DELETE",
       },

--- a/frontend/src/app/repository/adminTagRepository.ts
+++ b/frontend/src/app/repository/adminTagRepository.ts
@@ -2,6 +2,7 @@ import {
   fetchJsonOrThrow,
   requestOrThrow,
   API_BASE_URL,
+  ADMIN_API_BASE,
 } from "@/app/network/adminApi";
 
 export type Tag = {
@@ -16,7 +17,7 @@ class AdminTagRepository {
   }
 
   async create(name: string): Promise<Tag> {
-    const res = await requestOrThrow(`${API_BASE_URL}/api/admin/tags`, {
+    const res = await requestOrThrow(`${ADMIN_API_BASE}/tags`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name }),
@@ -25,7 +26,7 @@ class AdminTagRepository {
   }
 
   async update(id: number, name: string): Promise<Tag> {
-    const res = await requestOrThrow(`${API_BASE_URL}/api/admin/tags/${id}`, {
+    const res = await requestOrThrow(`${ADMIN_API_BASE}/tags/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name }),
@@ -34,13 +35,13 @@ class AdminTagRepository {
   }
 
   async delete(id: number): Promise<void> {
-    await requestOrThrow(`${API_BASE_URL}/api/admin/tags/${id}`, {
+    await requestOrThrow(`${ADMIN_API_BASE}/tags/${id}`, {
       method: "DELETE",
     });
   }
 
   async reorder(orders: { id: number; displayOrder: number }[]): Promise<void> {
-    await requestOrThrow(`${API_BASE_URL}/api/admin/tags/order`, {
+    await requestOrThrow(`${ADMIN_API_BASE}/tags/order`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ orders }),


### PR DESCRIPTION
## Summary
- admin API 呼び出しを Next.js API Route 経由でプロキシするように変更
- `auth_token` cookie が `kyo1941.com` ドメインにセットされているため、別ドメインの Railway バックエンドへの直接リクエストに cookie が付与されず 401 になっていた
- プロキシ Route がサーバーサイドで cookie を読み取り、バックエンドへ転送することで解決

## 変更内容
- `frontend/src/app/api/admin/[...path]/route.ts`: 新規作成。すべての `/api/admin/*` リクエストをバックエンドへプロキシし、`auth_token` cookie と `Origin` ヘッダーを転送
- `frontend/src/app/network/adminApi.ts`: `ADMIN_API_BASE = "/api/admin"` 定数を追加
- `frontend/src/app/repository/admin*.ts`: admin エンドポイントを `ADMIN_API_BASE` 経由に変更（public エンドポイントは `API_BASE_URL` のまま）

## ローカル再現について
開発環境では frontend/backend が同じ `localhost` 上で動くため、`SameSite=Strict` cookie が正常に送られ再現不可。本番環境（異なるドメイン）でのみ発生する問題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)