### PR TITLE
[Frontend] Always render career detail content in DOM for AI/SEO readability

### DIFF
--- a/frontend/src/app/ui/profile/section/CareerItem.tsx
+++ b/frontend/src/app/ui/profile/section/CareerItem.tsx
@@ -65,39 +65,37 @@ export default function CareerItem({
 
         {!isOpen && toggleButton(false)}
 
-        {isOpen && (
-          <>
-            <ul className="list-disc list-outside pl-5 text-gray-700">
-              {tasks.map((task, taskIndex) => (
-                <li key={taskIndex} className="mt-3 pl-1">
-                  {task.content}
-                  {task.details && task.details.length > 0 && (
-                    <ul className="list-[circle] list-outside pl-5 mt-1 text-gray-700">
-                      {task.details.map((sub, subIndex) => (
-                        <li key={subIndex} className="mt-2 pl-1">
-                          {sub}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </li>
+        <div className={isOpen ? "" : "hidden"}>
+          <ul className="list-disc list-outside pl-5 text-gray-700">
+            {tasks.map((task, taskIndex) => (
+              <li key={taskIndex} className="mt-3 pl-1">
+                {task.content}
+                {task.details && task.details.length > 0 && (
+                  <ul className="list-[circle] list-outside pl-5 mt-1 text-gray-700">
+                    {task.details.map((sub, subIndex) => (
+                      <li key={subIndex} className="mt-2 pl-1">
+                        {sub}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+          {technologies.length > 0 && (
+            <div className="mt-3.5 flex flex-wrap gap-2">
+              {technologies.map((tech) => (
+                <span
+                  key={tech}
+                  className="bg-gray-100 text-gray-800 text-xs font-medium px-2.5 py-1 rounded-full"
+                >
+                  {tech}
+                </span>
               ))}
-            </ul>
-            {technologies.length > 0 && (
-              <div className="mt-3.5 flex flex-wrap gap-2">
-                {technologies.map((tech) => (
-                  <span
-                    key={tech}
-                    className="bg-gray-100 text-gray-800 text-xs font-medium px-2.5 py-1 rounded-full"
-                  >
-                    {tech}
-                  </span>
-                ))}
-              </div>
-            )}
-            {toggleButton(true)}
-          </>
-        )}
+            </div>
+          )}
+          {toggleButton(true)}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 変更内容

- `CareerItem.tsx` のアコーディオン詳細部分を条件付きレンダリング（`{isOpen && ...}`）から CSS による表示制御（`hidden` クラス）に変更
- 閉じた状態でもコンテンツが HTML ソースに存在するようになり、AI ツール・検索エンジン・スクリーンリーダーがインターン経歴の詳細を読み取れるようになる
- レイアウト・挙動は変更なし

## 該当するissue

<!-- もしあれば -->