### PR TITLE
[Frontend] Cloudinaryの画像ドメインをNext.js設定に追加

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -15,7 +15,13 @@ const remotePattern: RemotePattern = {
 const nextConfig: NextConfig = {
   output: process.env.BUILD_STANDALONE === "true" ? "standalone" : undefined,
   images: {
-    remotePatterns: [remotePattern],
+    remotePatterns: [
+      remotePattern,
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
## 変更内容
- `next.config.ts` の `remotePatterns` に `res.cloudinary.com` を追加
- Cloudinaryにアップロードした画像のURLをポートフォリオの `coverImage` に設定した際、Next.js の `<Image>` コンポーネントで表示できなかった問題を修正

## 該当するissue

<!-- もしあれば -->