### PR TITLE
[Frontend] 記事が更新されたらキャッシュを更新する

### DIFF
--- a/frontend/src/app/api/admin/[...path]/route.ts
+++ b/frontend/src/app/api/admin/[...path]/route.ts
@@ -41,7 +41,10 @@ async function proxyAdmin(
     const resContentType =
       backendRes.headers.get("content-type") ?? "application/json";
 
-    if (backendRes.ok && (request.method === "PUT" || request.method === "DELETE")) {
+    if (
+      backendRes.ok &&
+      (request.method === "PUT" || request.method === "DELETE")
+    ) {
       if (path[0] === "blogs") {
         if (path[1]) revalidatePath(`/ui/blog/${path[1]}`);
       } else if (path[0] === "portfolios") {

--- a/frontend/src/app/api/admin/[...path]/route.ts
+++ b/frontend/src/app/api/admin/[...path]/route.ts
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 const BACKEND_URL =
@@ -39,6 +40,14 @@ async function proxyAdmin(
     const resBody = await backendRes.text();
     const resContentType =
       backendRes.headers.get("content-type") ?? "application/json";
+
+    if (backendRes.ok && hasBody) {
+      if (path[0] === "blogs") {
+        if (path[1]) revalidatePath(`/ui/blog/${path[1]}`);
+      } else if (path[0] === "portfolios") {
+        if (path[1]) revalidatePath(`/ui/portfolio/${path[1]}`);
+      }
+    }
 
     return new NextResponse(resBody || null, {
       status: backendRes.status,

--- a/frontend/src/app/api/admin/[...path]/route.ts
+++ b/frontend/src/app/api/admin/[...path]/route.ts
@@ -41,7 +41,7 @@ async function proxyAdmin(
     const resContentType =
       backendRes.headers.get("content-type") ?? "application/json";
 
-    if (backendRes.ok && hasBody) {
+    if (backendRes.ok && (request.method === "PUT" || request.method === "DELETE")) {
       if (path[0] === "blogs") {
         if (path[1]) revalidatePath(`/ui/blog/${path[1]}`);
       } else if (path[0] === "portfolios") {


### PR DESCRIPTION
## 変更内容

- Admin画面でブログ/ポートフォリオを更新・削除した際に、対応する詳細ページの静的キャッシュを即時無効化するよう修正
- `frontend/src/app/api/admin/[...path]/route.ts` の Admin プロキシルートに `revalidatePath()` を追加
- PUT/DELETE が成功した場合のみ `/ui/blog/[slug]` または `/ui/portfolio/[slug]` を revalidate する

## 該当するissue

<!-- もしあれば -->