### PR TITLE
[Frontend/Backend] ブログ・ポートフォリオコンテンツにURLプレビューカードを追加

### DIFF
--- a/backend/app/src/main/kotlin/my/backend/di/AppModule.kt
+++ b/backend/app/src/main/kotlin/my/backend/di/AppModule.kt
@@ -21,6 +21,7 @@ import my.backend.repository.UserRepositoryImpl
 import my.backend.service.AuthService
 import my.backend.service.BlogService
 import my.backend.service.ContactService
+import my.backend.service.OgpService
 import my.backend.service.PortfolioService
 import my.backend.service.TagService
 import org.koin.dsl.module
@@ -68,6 +69,7 @@ fun appModule(config: ApplicationConfig) =
         // Services
         single { BlogService(get()) }
         single { ContactService(get(), get(), get()) }
+        single { OgpService(get()) }
         single { PortfolioService(get()) }
         single { AuthService(get(), get()) }
         single { TagService(get()) }

--- a/backend/app/src/main/kotlin/my/backend/di/AppModule.kt
+++ b/backend/app/src/main/kotlin/my/backend/di/AppModule.kt
@@ -24,6 +24,7 @@ import my.backend.service.ContactService
 import my.backend.service.OgpService
 import my.backend.service.PortfolioService
 import my.backend.service.TagService
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.dsl.onClose
 
@@ -57,6 +58,12 @@ fun appModule(config: ApplicationConfig) =
             HttpClient(CIO) { install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } }
         } onClose { it?.close() }
 
+        // HttpClient (OGP取得用, ContentNegotiation なし)
+        // OGP取得は HTML を生テキストとして読むだけであり、JSON API 呼び出しとは用途が異なるため専用クライアントを使う
+        single(named("ogp")) {
+            HttpClient(CIO)
+        } onClose { it?.close() }
+
         // Resend (メール送信用)
         single { Resend(config.property("app.resend.api-key").getString()) }
 
@@ -69,7 +76,7 @@ fun appModule(config: ApplicationConfig) =
         // Services
         single { BlogService(get()) }
         single { ContactService(get(), get(), get()) }
-        single { OgpService(get()) }
+        single { OgpService(get(named("ogp"))) }
         single { PortfolioService(get()) }
         single { AuthService(get(), get()) }
         single { TagService(get()) }

--- a/backend/app/src/main/kotlin/my/backend/dto/OgpDto.kt
+++ b/backend/app/src/main/kotlin/my/backend/dto/OgpDto.kt
@@ -1,0 +1,13 @@
+package my.backend.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OgpResponseDto(
+    val url: String,
+    val title: String? = null,
+    val description: String? = null,
+    val image: String? = null,
+    val siteName: String? = null,
+    val favicon: String? = null,
+)

--- a/backend/app/src/main/kotlin/my/backend/plugins/Routing.kt
+++ b/backend/app/src/main/kotlin/my/backend/plugins/Routing.kt
@@ -6,11 +6,13 @@ import io.ktor.server.routing.*
 import my.backend.routes.authRoutes
 import my.backend.routes.blogRoutes
 import my.backend.routes.contactRoutes
+import my.backend.routes.ogpRoutes
 import my.backend.routes.portfolioRoutes
 import my.backend.routes.tagRoutes
 import my.backend.service.AuthService
 import my.backend.service.BlogService
 import my.backend.service.ContactService
+import my.backend.service.OgpService
 import my.backend.service.PortfolioService
 import my.backend.service.TagService
 import org.koin.ktor.ext.inject
@@ -18,6 +20,7 @@ import org.koin.ktor.ext.inject
 fun Application.configureRouting() {
     val blogService by inject<BlogService>()
     val contactService by inject<ContactService>()
+    val ogpService by inject<OgpService>()
     val portfolioService by inject<PortfolioService>()
     val authService by inject<AuthService>()
     val tagService by inject<TagService>()
@@ -25,6 +28,7 @@ fun Application.configureRouting() {
     routing {
         blogRoutes(blogService)
         contactRoutes(contactService)
+        ogpRoutes(ogpService)
         portfolioRoutes(portfolioService)
         authRoutes(authService)
         tagRoutes(tagService)

--- a/backend/app/src/main/kotlin/my/backend/routes/OgpRoutes.kt
+++ b/backend/app/src/main/kotlin/my/backend/routes/OgpRoutes.kt
@@ -1,0 +1,21 @@
+package my.backend.routes
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import my.backend.service.OgpService
+
+fun Route.ogpRoutes(ogpService: OgpService) {
+    route("/api/ogp") {
+        get {
+            val rawUrl =
+                call.request.queryParameters["url"]
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, "url is required")
+            val result =
+                ogpService.fetchOgp(rawUrl)
+                    ?: return@get call.respond(HttpStatusCode.NotFound)
+            call.respond(result)
+        }
+    }
+}

--- a/backend/app/src/main/kotlin/my/backend/service/OgpService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/OgpService.kt
@@ -14,17 +14,20 @@ import java.util.concurrent.ConcurrentHashMap
 
 class OgpService(private val client: HttpClient) {
     private val logger = LoggerFactory.getLogger(OgpService::class.java)
-    private val cache = ConcurrentHashMap<String, OgpResponseDto?>()
+    private val cache = ConcurrentHashMap<String, OgpResponseDto>()
+
+    // NOTE: ConcurrentHashMap は null 値を許容しないため、取得失敗をセンチネルで表す
+    private val failed = OgpResponseDto(url = "")
 
     suspend fun fetchOgp(rawUrl: String): OgpResponseDto? {
-        if (cache.containsKey(rawUrl)) return cache[rawUrl]
+        cache[rawUrl]?.let { return if (it === failed) null else it }
 
         val result =
             runCatching { doFetch(rawUrl) }.getOrElse {
                 logger.warn("Failed to fetch OGP for $rawUrl: ${it.message}")
                 null
             }
-        cache[rawUrl] = result
+        cache[rawUrl] = result ?: failed
         return result
     }
 
@@ -34,7 +37,11 @@ class OgpService(private val client: HttpClient) {
         val uri = URI(rawUrl)
         val host = uri.host ?: return null
         val address = runCatching { InetAddress.getByName(host) }.getOrNull() ?: return null
-        if (address.isLoopbackAddress || address.isSiteLocalAddress) return null
+        if (address.isLoopbackAddress || address.isSiteLocalAddress ||
+            address.isLinkLocalAddress || address.isMulticastAddress
+        ) {
+            return null
+        }
 
         val html =
             withTimeout(5_000) {

--- a/backend/app/src/main/kotlin/my/backend/service/OgpService.kt
+++ b/backend/app/src/main/kotlin/my/backend/service/OgpService.kt
@@ -1,0 +1,80 @@
+package my.backend.service
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.withTimeout
+import my.backend.dto.OgpResponseDto
+import org.jsoup.Jsoup
+import org.slf4j.LoggerFactory
+import java.net.InetAddress
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+
+class OgpService(private val client: HttpClient) {
+    private val logger = LoggerFactory.getLogger(OgpService::class.java)
+    private val cache = ConcurrentHashMap<String, OgpResponseDto?>()
+
+    suspend fun fetchOgp(rawUrl: String): OgpResponseDto? {
+        if (cache.containsKey(rawUrl)) return cache[rawUrl]
+
+        val result =
+            runCatching { doFetch(rawUrl) }.getOrElse {
+                logger.warn("Failed to fetch OGP for $rawUrl: ${it.message}")
+                null
+            }
+        cache[rawUrl] = result
+        return result
+    }
+
+    private suspend fun doFetch(rawUrl: String): OgpResponseDto? {
+        if (!rawUrl.startsWith("http://") && !rawUrl.startsWith("https://")) return null
+
+        val uri = URI(rawUrl)
+        val host = uri.host ?: return null
+        val address = runCatching { InetAddress.getByName(host) }.getOrNull() ?: return null
+        if (address.isLoopbackAddress || address.isSiteLocalAddress) return null
+
+        val html =
+            withTimeout(5_000) {
+                val response =
+                    client.get(rawUrl) {
+                        headers { append(HttpHeaders.UserAgent, "Mozilla/5.0 (compatible; OGPBot/1.0)") }
+                    }
+                if (!response.status.isSuccess()) return@withTimeout null
+                val contentType = response.contentType()?.contentType
+                if (contentType != "text") return@withTimeout null
+                response.bodyAsText()
+            } ?: return null
+
+        return parseOgp(rawUrl, html)
+    }
+
+    private fun parseOgp(
+        pageUrl: String,
+        html: String,
+    ): OgpResponseDto {
+        val doc = Jsoup.parse(html, pageUrl)
+
+        fun meta(property: String): String? =
+            doc.selectFirst("meta[property=$property]")?.attr("content")?.takeIf { it.isNotBlank() }
+                ?: doc.selectFirst("meta[name=$property]")?.attr("content")?.takeIf { it.isNotBlank() }
+
+        fun resolveUrl(href: String?): String? {
+            if (href.isNullOrBlank()) return null
+            return runCatching { URI(pageUrl).resolve(href).toString() }.getOrNull()
+        }
+
+        val favicon = doc.selectFirst("link[rel~=icon]")?.attr("href")?.let { resolveUrl(it) }
+
+        return OgpResponseDto(
+            url = pageUrl,
+            title = meta("og:title") ?: doc.title().takeIf { it.isNotBlank() },
+            description = meta("og:description") ?: meta("description"),
+            image = resolveUrl(meta("og:image")),
+            siteName = meta("og:site_name"),
+            favicon = favicon,
+        )
+    }
+}

--- a/frontend/src/app/admin/components/AdminMarkdownPreview.tsx
+++ b/frontend/src/app/admin/components/AdminMarkdownPreview.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import ReactMarkdown from "react-markdown";
-import rehypeHighlight from "rehype-highlight";
-import rehypeRaw from "rehype-raw";
-import remarkGfm from "remark-gfm";
+import { useOgpData } from "@/app/hooks/admin/useOgpData";
+import { MarkdownRenderer } from "@/app/components/MarkdownRenderer";
 
 type AdminMarkdownPreviewProps = {
   content: string;
@@ -11,6 +9,7 @@ type AdminMarkdownPreviewProps = {
 
 export function AdminMarkdownPreview({ content }: AdminMarkdownPreviewProps) {
   const hasContent = content.trim().length > 0;
+  const ogpData = useOgpData(content);
 
   return (
     <div>
@@ -18,12 +17,7 @@ export function AdminMarkdownPreview({ content }: AdminMarkdownPreviewProps) {
       <aside className="self-start rounded border bg-white p-6 shadow lg:sticky lg:top-8">
         <div className="prose max-w-none">
           {hasContent ? (
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeHighlight, rehypeRaw]}
-            >
-              {content}
-            </ReactMarkdown>
+            <MarkdownRenderer content={content} ogpData={ogpData} />
           ) : (
             <p className="text-sm text-gray-500">
               本文を入力するとここにプレビューが表示されます。

--- a/frontend/src/app/components/LinkPreviewCard.tsx
+++ b/frontend/src/app/components/LinkPreviewCard.tsx
@@ -1,0 +1,60 @@
+import type { OgpData } from "@/app/types/ogp";
+
+type Props = {
+  data: OgpData;
+};
+
+export function LinkPreviewCard({ data }: Props) {
+  const domain = (() => {
+    try {
+      return new URL(data.url).hostname;
+    } catch {
+      return data.url;
+    }
+  })();
+
+  return (
+    <a
+      href={data.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="not-prose my-4 flex overflow-hidden rounded-lg border border-gray-200 no-underline transition-colors hover:bg-gray-50"
+    >
+      {data.image && (
+        <div className="hidden flex-shrink-0 sm:block sm:w-48">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={data.image}
+            alt={data.title ?? ""}
+            className="h-full w-full object-cover"
+          />
+        </div>
+      )}
+      <div className="flex min-w-0 flex-col gap-1 p-4">
+        {data.title && (
+          <span className="line-clamp-2 text-sm font-semibold text-gray-900">
+            {data.title}
+          </span>
+        )}
+        {data.description && (
+          <span className="line-clamp-2 text-xs text-gray-500">
+            {data.description}
+          </span>
+        )}
+        <div className="mt-auto flex items-center gap-2 text-xs text-gray-400">
+          {data.favicon && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={data.favicon}
+              alt=""
+              width={14}
+              height={14}
+              className="rounded-sm"
+            />
+          )}
+          <span className="truncate">{data.siteName ?? domain}</span>
+        </div>
+      </div>
+    </a>
+  );
+}

--- a/frontend/src/app/components/MarkdownRenderer.tsx
+++ b/frontend/src/app/components/MarkdownRenderer.tsx
@@ -1,0 +1,39 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import rehypeRaw from "rehype-raw";
+import type { OgpData } from "@/app/types/ogp";
+import { remarkLinkPreview } from "@/app/utils/remarkLinkPreview";
+import { LinkPreviewCard } from "@/app/components/LinkPreviewCard";
+
+type Props = {
+  content: string;
+  ogpData?: Record<string, OgpData>;
+};
+
+export function MarkdownRenderer({ content, ogpData = {} }: Props) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkLinkPreview]}
+      rehypePlugins={[rehypeHighlight, rehypeRaw]}
+      components={{
+        p({ children, ...props }) {
+          const previewUrl = (props as Record<string, unknown>)[
+            "data-link-preview"
+          ] as string | undefined;
+
+          if (previewUrl) {
+            const data = ogpData[previewUrl];
+            if (data) {
+              return <LinkPreviewCard data={data} />;
+            }
+          }
+
+          return <p {...props}>{children}</p>;
+        },
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/src/app/hooks/admin/useOgpData.ts
+++ b/frontend/src/app/hooks/admin/useOgpData.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { OgpData } from "@/app/types/ogp";
+import { API_BASE_URL } from "@/app/network/publicApi";
+import { extractBareUrls } from "@/app/utils/extractBareUrls";
+
+export function useOgpData(content: string): Record<string, OgpData> {
+  const [ogpData, setOgpData] = useState<Record<string, OgpData>>({});
+
+  useEffect(() => {
+    const urls = extractBareUrls(content);
+    if (urls.length === 0) return;
+
+    const missing = urls.filter((u) => !(u in ogpData));
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+
+    Promise.all(
+      missing.map(async (url) => {
+        try {
+          const res = await fetch(
+            `${API_BASE_URL}/api/ogp?url=${encodeURIComponent(url)}`,
+          );
+          if (!res.ok) return null;
+          const data: OgpData = await res.json();
+          return [url, data] as const;
+        } catch {
+          return null;
+        }
+      }),
+    ).then((results) => {
+      if (cancelled) return;
+      const newEntries = results.filter(
+        (r): r is [string, OgpData] => r !== null,
+      );
+      if (newEntries.length > 0) {
+        setOgpData((prev) => ({ ...prev, ...Object.fromEntries(newEntries) }));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // ogpData は意図的にdepsから除外 (セッションキャッシュとして機能させる)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content]);
+
+  return ogpData;
+}

--- a/frontend/src/app/repository/ogpRepository.ts
+++ b/frontend/src/app/repository/ogpRepository.ts
@@ -1,0 +1,25 @@
+import { API_BASE_URL, fetchJsonOrNull } from "@/app/network/publicApi";
+import type { OgpData } from "@/app/types/ogp";
+
+class OgpRepository {
+  private async fetchOgp(url: string): Promise<OgpData | null> {
+    return fetchJsonOrNull<OgpData>(
+      `${API_BASE_URL}/api/ogp?url=${encodeURIComponent(url)}`,
+    );
+  }
+
+  async fetchOgpBatch(urls: string[]): Promise<Record<string, OgpData>> {
+    if (urls.length === 0) return {};
+    const results = await Promise.all(
+      urls.map(async (url) => {
+        const data = await this.fetchOgp(url);
+        return data ? ([url, data] as const) : null;
+      }),
+    );
+    return Object.fromEntries(
+      results.filter((r): r is [string, OgpData] => r !== null),
+    );
+  }
+}
+
+export const ogpRepository = new OgpRepository();

--- a/frontend/src/app/types/ogp.ts
+++ b/frontend/src/app/types/ogp.ts
@@ -1,0 +1,8 @@
+export type OgpData = {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  favicon?: string;
+};

--- a/frontend/src/app/ui/blog/[slug]/page.tsx
+++ b/frontend/src/app/ui/blog/[slug]/page.tsx
@@ -1,10 +1,9 @@
 import { blogRepository } from "@/app/repository/blogRepository";
+import { ogpRepository } from "@/app/repository/ogpRepository";
+import { extractBareUrls } from "@/app/utils/extractBareUrls";
 import Header from "@/app/components/header";
 import BackButton from "@/app/components/BackButton";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
-import rehypeRaw from "rehype-raw";
+import { MarkdownRenderer } from "@/app/components/MarkdownRenderer";
 import { ROUTES } from "@/app/routes";
 
 // ブログページの生成に必要なパスを事前に取得する関数
@@ -23,6 +22,9 @@ export default async function PostPage({
 }) {
   const { slug } = await params;
   const postData = await blogRepository.getPostData(slug);
+  const ogpData = postData
+    ? await ogpRepository.fetchOgpBatch(extractBareUrls(postData.content))
+    : {};
 
   if (!postData) {
     return (
@@ -64,12 +66,7 @@ export default async function PostPage({
 
             {/* 本文 (ReactMarkdownでレンダリング) */}
             <div className="prose prose-lg max-w-none">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeHighlight, rehypeRaw]}
-              >
-                {postData.content}
-              </ReactMarkdown>
+              <MarkdownRenderer content={postData.content} ogpData={ogpData} />
             </div>
           </article>
         </div>

--- a/frontend/src/app/ui/portfolio/[slug]/page.tsx
+++ b/frontend/src/app/ui/portfolio/[slug]/page.tsx
@@ -1,10 +1,9 @@
 import { portfolioRepository } from "@/app/repository/portfolioRepository";
+import { ogpRepository } from "@/app/repository/ogpRepository";
+import { extractBareUrls } from "@/app/utils/extractBareUrls";
 import Header from "@/app/components/header";
 import BackButton from "@/app/components/BackButton";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
-import rehypeRaw from "rehype-raw";
+import { MarkdownRenderer } from "@/app/components/MarkdownRenderer";
 import { ROUTES } from "@/app/routes";
 
 // ポートフォリオページの生成に必要なパスを事前に取得する関数
@@ -23,6 +22,9 @@ export default async function PortfolioDetailPage({
 }) {
   const { slug } = await params;
   const portfolioData = await portfolioRepository.getPostData(slug);
+  const ogpData = portfolioData
+    ? await ogpRepository.fetchOgpBatch(extractBareUrls(portfolioData.content))
+    : {};
 
   if (!portfolioData) {
     return (
@@ -64,12 +66,10 @@ export default async function PortfolioDetailPage({
 
             {/* 本文 (ReactMarkdownでレンダリング) */}
             <div className="prose prose-lg max-w-none">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeHighlight, rehypeRaw]}
-              >
-                {portfolioData.content}
-              </ReactMarkdown>
+              <MarkdownRenderer
+                content={portfolioData.content}
+                ogpData={ogpData}
+              />
             </div>
           </article>
         </div>

--- a/frontend/src/app/utils/extractBareUrls.ts
+++ b/frontend/src/app/utils/extractBareUrls.ts
@@ -1,0 +1,10 @@
+const URL_REGEX = /^https?:\/\/\S+$/;
+
+export function extractBareUrls(markdown: string): string[] {
+  const urls: string[] = [];
+  for (const line of markdown.split("\n")) {
+    const trimmed = line.trim();
+    if (URL_REGEX.test(trimmed)) urls.push(trimmed);
+  }
+  return [...new Set(urls)];
+}

--- a/frontend/src/app/utils/remarkLinkPreview.ts
+++ b/frontend/src/app/utils/remarkLinkPreview.ts
@@ -1,0 +1,23 @@
+import { visit } from "unist-util-visit";
+import type { Plugin } from "unified";
+import type { Root, Paragraph, Link, Text } from "mdast";
+
+export const remarkLinkPreview: Plugin<[], Root> = () => (tree) => {
+  visit(tree, "paragraph", (node: Paragraph) => {
+    if (node.children.length !== 1) return;
+    const child = node.children[0];
+    if (child.type !== "link") return;
+
+    const link = child as Link;
+    if (link.children.length !== 1) return;
+    const linkText = link.children[0] as Text;
+    if (linkText.type !== "text") return;
+    if (linkText.value !== link.url) return;
+
+    node.data = node.data ?? {};
+    node.data.hProperties = {
+      ...(node.data.hProperties as Record<string, unknown> | undefined),
+      "data-link-preview": link.url,
+    };
+  });
+};


### PR DESCRIPTION
## 変更内容

- Markdown コンテンツ内で URL が単独で1行に書かれている場合、OGP リンクプレビューカード（タイトル・説明・サムネイル・favicon）として表示されるようにした
- バックエンドに `GET /api/ogp?url=...` エンドポイントを追加（Jsoup で OGP タグを解析、SSRF 対策・in-memory キャッシュ付き）
- 公開ページ（ブログ・ポートフォリオ詳細）はサーバーコンポーネントで SSG ビルド時に OGP データを pre-fetch
- 管理画面プレビューは `useOgpData` フックでクライアント側からリアルタイムフェッチ
- OGP 取得失敗時は通常のリンクにフォールバック

## 該当するissue

- close #141