### PR TITLE
[Frontend] 記事投稿後にブログ一覧へ即時反映されないキャッシュバグを修正

### DIFF
--- a/frontend/src/app/api/admin/[...path]/route.ts
+++ b/frontend/src/app/api/admin/[...path]/route.ts
@@ -41,14 +41,16 @@ async function proxyAdmin(
     const resContentType =
       backendRes.headers.get("content-type") ?? "application/json";
 
-    if (
-      backendRes.ok &&
-      (request.method === "PUT" || request.method === "DELETE")
-    ) {
+    if (backendRes.ok) {
       if (path[0] === "blogs") {
+        revalidatePath("/ui/blog");
         if (path[1]) revalidatePath(`/ui/blog/${path[1]}`);
       } else if (path[0] === "portfolios") {
+        revalidatePath("/ui/portfolio");
         if (path[1]) revalidatePath(`/ui/portfolio/${path[1]}`);
+      } else if (path[0] === "tags") {
+        revalidatePath("/ui/blog");
+        revalidatePath("/ui/portfolio");
       }
     }
 

--- a/frontend/src/app/ui/blog/[slug]/page.tsx
+++ b/frontend/src/app/ui/blog/[slug]/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = false;
+
 import { blogRepository } from "@/app/repository/blogRepository";
 import { ogpRepository } from "@/app/repository/ogpRepository";
 import { extractBareUrls } from "@/app/utils/extractBareUrls";

--- a/frontend/src/app/ui/blog/page.tsx
+++ b/frontend/src/app/ui/blog/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = false;
+
 import Header from "@/app/components/header";
 import BlogListSection from "./section/BlogListSection";
 import TextSearchSection from "./section/TextSearchSection";

--- a/frontend/src/app/ui/portfolio/[slug]/page.tsx
+++ b/frontend/src/app/ui/portfolio/[slug]/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = false;
+
 import { portfolioRepository } from "@/app/repository/portfolioRepository";
 import { ogpRepository } from "@/app/repository/ogpRepository";
 import { extractBareUrls } from "@/app/utils/extractBareUrls";

--- a/frontend/src/app/ui/portfolio/page.tsx
+++ b/frontend/src/app/ui/portfolio/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = false;
+
 import Header from "@/app/components/header";
 import PortfolioListSection from "./section/PortfolioListSection";
 import { portfolioRepository } from "@/app/repository/portfolioRepository";


### PR DESCRIPTION
## 変更内容

- `revalidatePath` の呼び出しを POST（新規投稿）を含む全操作に拡張した（従来は PUT/DELETE のみ）
- ブログ・ポートフォリオの一覧ページ（`/ui/blog`, `/ui/portfolio`）も revalidate 対象に追加（従来は個別記事のみ）
- タグ操作時もブログ・ポートフォリオ一覧を revalidate するよう追加
- ブログ・ポートフォリオの各ページに `export const revalidate = false` を追加し、Full Route Cache に入る Static ページとして扱うことで `revalidatePath` が有効になるようにした

## 該当するissue

<!-- もしあれば -->