### PR TITLE
[Frontend] キャリアデータの XFT 誤字を CFT に修正

### DIFF
--- a/frontend/src/app/data/careerData.ts
+++ b/frontend/src/app/data/careerData.ts
@@ -44,7 +44,7 @@ export const careerData: Career[] = [
       {
         content: "Splash Screen におけるロゴの差し替えを担当",
         details: [
-          "ガイドラインや API 仕様でのデザイン調整や、試作を通した XFT での調整を行い実装",
+          "ガイドラインや API 仕様でのデザイン調整や、試作を通した CFT での調整を行い実装",
         ],
       },
       { content: "その他、レガシーな技術のリプレイスも担当" },


### PR DESCRIPTION
## 変更内容
- `careerData.ts` 内の MIXI 項目で誤って使用していた XFT (誤) を CFT (Cross-Functional Team の正式略称) に修正

## 該当するissue

<!-- もしあれば -->