### PR TITLE
[Frontend] コードブロックの背景色・paddingを言語ラベルの有無で統一

### DIFF
--- a/frontend/src/app/components/CodeBlock.tsx
+++ b/frontend/src/app/components/CodeBlock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FiCopy, FiCheck } from "react-icons/fi";
 
 type Props = {
@@ -16,8 +16,13 @@ export function CodeBlock({ language, children }: Props) {
     const text = preRef.current?.textContent ?? "";
     await navigator.clipboard.writeText(text);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
   };
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
 
   return (
     <div className="my-4 rounded-md overflow-hidden border border-gray-700">
@@ -26,6 +31,7 @@ export function CodeBlock({ language, children }: Props) {
           {language ?? ""}
         </span>
         <button
+          type="button"
           onClick={handleCopy}
           className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-100 transition-colors cursor-pointer select-none"
         >

--- a/frontend/src/app/components/CodeBlock.tsx
+++ b/frontend/src/app/components/CodeBlock.tsx
@@ -42,7 +42,7 @@ export function CodeBlock({ language, children }: Props) {
           )}
         </button>
       </div>
-      <pre ref={preRef} className="!my-0 !rounded-none">
+      <pre ref={preRef} className="!my-0 !rounded-none !bg-[#0d1117] !p-0">
         {children}
       </pre>
     </div>

--- a/frontend/src/app/components/CodeBlock.tsx
+++ b/frontend/src/app/components/CodeBlock.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { FiCopy, FiCheck } from "react-icons/fi";
+
+type Props = {
+  language?: string;
+  children: React.ReactNode;
+};
+
+export function CodeBlock({ language, children }: Props) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text = preRef.current?.textContent ?? "";
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="my-4 rounded-md overflow-hidden border border-gray-700">
+      <div className="flex items-center justify-between px-4 py-1.5 bg-[#161b22] border-b border-gray-700">
+        <span className="text-xs text-gray-400 font-mono">
+          {language ?? ""}
+        </span>
+        <button
+          onClick={handleCopy}
+          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-100 transition-colors cursor-pointer select-none"
+        >
+          {copied ? (
+            <>
+              <FiCheck size={13} />
+              Copied!
+            </>
+          ) : (
+            <>
+              <FiCopy size={13} />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+      <pre ref={preRef} className="!my-0 !rounded-none">
+        {children}
+      </pre>
+    </div>
+  );
+}

--- a/frontend/src/app/components/MarkdownRenderer.tsx
+++ b/frontend/src/app/components/MarkdownRenderer.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -5,6 +6,7 @@ import rehypeRaw from "rehype-raw";
 import type { OgpData } from "@/app/types/ogp";
 import { remarkLinkPreview } from "@/app/utils/remarkLinkPreview";
 import { LinkPreviewCard } from "@/app/components/LinkPreviewCard";
+import { CodeBlock } from "@/app/components/CodeBlock";
 
 type Props = {
   content: string;
@@ -17,6 +19,17 @@ export function MarkdownRenderer({ content, ogpData = {} }: Props) {
       remarkPlugins={[remarkGfm, remarkLinkPreview]}
       rehypePlugins={[rehypeHighlight, rehypeRaw]}
       components={{
+        pre({ children }) {
+          let language: string | undefined;
+          if (React.isValidElement(children)) {
+            const codeEl = children as React.ReactElement<{
+              className?: string;
+            }>;
+            const m = (codeEl.props.className ?? "").match(/language-(\S+)/);
+            language = m?.[1];
+          }
+          return <CodeBlock language={language}>{children}</CodeBlock>;
+        },
         p({ children, ...props }) {
           const previewUrl = (props as Record<string, unknown>)[
             "data-link-preview"

--- a/frontend/src/app/components/MarkdownRenderer.tsx
+++ b/frontend/src/app/components/MarkdownRenderer.tsx
@@ -20,14 +20,13 @@ export function MarkdownRenderer({ content, ogpData = {} }: Props) {
       rehypePlugins={[rehypeHighlight, rehypeRaw]}
       components={{
         pre({ children }) {
-          let language: string | undefined;
-          if (React.isValidElement(children)) {
-            const codeEl = children as React.ReactElement<{
-              className?: string;
-            }>;
-            const m = (codeEl.props.className ?? "").match(/language-(\S+)/);
-            language = m?.[1];
-          }
+          const codeElement = React.Children.toArray(children).find(
+            (child) =>
+              React.isValidElement(child) &&
+              (child as React.ReactElement).type === "code",
+          ) as React.ReactElement<{ className?: string }> | undefined;
+          const language =
+            codeElement?.props.className?.match(/language-(\S+)/)?.[1];
           return <CodeBlock language={language}>{children}</CodeBlock>;
         },
         p({ children, ...props }) {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "highlight.js/styles/github-dark.css";
 @plugin '@tailwindcss/typography';
 
 :root {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 @import "highlight.js/styles/github-dark.css";
+
+pre code:not(.hljs) {
+  display: block;
+  padding: 1em;
+}
 @plugin '@tailwindcss/typography';
 
 :root {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4,6 +4,7 @@
 pre code:not(.hljs) {
   display: block;
   padding: 1em;
+  overflow-x: auto;
 }
 @plugin '@tailwindcss/typography';
 


### PR DESCRIPTION
## 変更内容
- コードブロックの `<pre>` 背景色を `#0d1117` に固定し、言語ラベルあり時に紺色がはみ出す問題を修正
- `<pre>` の padding を除去し、言語あり（`.hljs` padding）・言語なし（`pre code:not(.hljs)` padding）で同一の余白になるよう統一

## 該当するissue

<!-- もしあれば -->