### PR TITLE
[Frontend] Markdownエディタにリストの改行・タブインデント機能を追加

### DIFF
--- a/frontend/src/app/admin/blog/create/page.tsx
+++ b/frontend/src/app/admin/blog/create/page.tsx
@@ -37,7 +37,7 @@ export default function CreateBlogPage() {
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
 
-  const { onKeyDown } = useMarkdownListEditor(content, setContent);
+  const { onKeyDown } = useMarkdownListEditor(setContent);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/app/admin/blog/create/page.tsx
+++ b/frontend/src/app/admin/blog/create/page.tsx
@@ -6,6 +6,7 @@ import { useAdminBlogCreate } from "@/app/hooks/admin/useAdminBlogCreate";
 import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
 import { AdminMarkdownPreview } from "@/app/admin/components/AdminMarkdownPreview";
 import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
+import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
 
 export default function CreateBlogPage() {
   const router = useRouter();
@@ -35,6 +36,8 @@ export default function CreateBlogPage() {
 
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
+
+  const { onKeyDown } = useMarkdownListEditor(content, setContent);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -122,6 +125,7 @@ export default function CreateBlogPage() {
               onChange={(e) => setContent(e.target.value)}
               onCompositionStart={onCompositionStart}
               onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
+              onKeyDown={onKeyDown}
               required
             />
           </div>

--- a/frontend/src/app/admin/blog/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/blog/edit/[slug]/page.tsx
@@ -41,7 +41,7 @@ export default function EditBlogPage() {
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
 
-  const { onKeyDown } = useMarkdownListEditor(content, setContent);
+  const { onKeyDown } = useMarkdownListEditor(setContent);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/app/admin/blog/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/blog/edit/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { useAdminBlogEdit } from "@/app/hooks/admin/useAdminBlogEdit";
 import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
 import { AdminMarkdownPreview } from "@/app/admin/components/AdminMarkdownPreview";
 import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
+import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
 
 export default function EditBlogPage() {
   const router = useRouter();
@@ -39,6 +40,8 @@ export default function EditBlogPage() {
 
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
+
+  const { onKeyDown } = useMarkdownListEditor(content, setContent);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -126,6 +129,7 @@ export default function EditBlogPage() {
               onChange={(e) => setContent(e.target.value)}
               onCompositionStart={onCompositionStart}
               onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
+              onKeyDown={onKeyDown}
               required
             />
           </div>

--- a/frontend/src/app/admin/portfolio/create/page.tsx
+++ b/frontend/src/app/admin/portfolio/create/page.tsx
@@ -32,7 +32,7 @@ export default function CreatePortfolioPage() {
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
 
-  const { onKeyDown } = useMarkdownListEditor(content, setContent);
+  const { onKeyDown } = useMarkdownListEditor(setContent);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/app/admin/portfolio/create/page.tsx
+++ b/frontend/src/app/admin/portfolio/create/page.tsx
@@ -5,6 +5,7 @@ import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminPortfolioCreate } from "@/app/hooks/admin/useAdminPortfolioCreate";
 import { AdminMarkdownPreview } from "@/app/admin/components/AdminMarkdownPreview";
 import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
+import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
 
 export default function CreatePortfolioPage() {
   const router = useRouter();
@@ -30,6 +31,8 @@ export default function CreatePortfolioPage() {
 
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
+
+  const { onKeyDown } = useMarkdownListEditor(content, setContent);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -108,6 +111,7 @@ export default function CreatePortfolioPage() {
               onChange={(e) => setContent(e.target.value)}
               onCompositionStart={onCompositionStart}
               onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
+              onKeyDown={onKeyDown}
               required
             />
           </div>

--- a/frontend/src/app/admin/portfolio/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/portfolio/edit/[slug]/page.tsx
@@ -36,7 +36,7 @@ export default function EditPortfolioPage() {
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
 
-  const { onKeyDown } = useMarkdownListEditor(content, setContent);
+  const { onKeyDown } = useMarkdownListEditor(setContent);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/app/admin/portfolio/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/portfolio/edit/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminPortfolioEdit } from "@/app/hooks/admin/useAdminPortfolioEdit";
 import { AdminMarkdownPreview } from "@/app/admin/components/AdminMarkdownPreview";
 import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
+import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
 
 export default function EditPortfolioPage() {
   const router = useRouter();
@@ -34,6 +35,8 @@ export default function EditPortfolioPage() {
 
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
+
+  const { onKeyDown } = useMarkdownListEditor(content, setContent);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -112,6 +115,7 @@ export default function EditPortfolioPage() {
               onChange={(e) => setContent(e.target.value)}
               onCompositionStart={onCompositionStart}
               onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
+              onKeyDown={onKeyDown}
               required
             />
           </div>

--- a/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
+++ b/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+export function useMarkdownListEditor(
+  _content: string,
+  setContent: (value: string) => void,
+) {
+  const pendingCursorRef = useRef<number | null>(null);
+
+  const applyEdit = useCallback(
+    (textarea: HTMLTextAreaElement, newValue: string, newCursor: number) => {
+      pendingCursorRef.current = newCursor;
+      setContent(newValue);
+      requestAnimationFrame(() => {
+        const pos = pendingCursorRef.current;
+        if (pos !== null) {
+          textarea.setSelectionRange(pos, pos);
+          pendingCursorRef.current = null;
+        }
+      });
+    },
+    [setContent],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.nativeEvent.isComposing) return;
+
+      const textarea = e.currentTarget;
+      const { value, selectionStart, selectionEnd } = textarea;
+
+      if (selectionStart !== selectionEnd) return;
+
+      const cursor = selectionStart;
+      const lineStart = value.lastIndexOf("\n", cursor - 1) + 1;
+      const lineEndRaw = value.indexOf("\n", cursor);
+      const lineEnd = lineEndRaw === -1 ? value.length : lineEndRaw;
+      const currentLine = value.slice(lineStart, lineEnd);
+
+      if (e.key === "Enter") {
+        const listMatch = currentLine.match(/^(\s*)- (.*)/);
+        if (!listMatch) return;
+
+        e.preventDefault();
+        const indent = listMatch[1];
+        const itemContent = listMatch[2];
+
+        if (itemContent !== "") {
+          const insertion = `\n${indent}- `;
+          const newValue =
+            value.slice(0, cursor) + insertion + value.slice(cursor);
+          applyEdit(textarea, newValue, cursor + insertion.length);
+        } else if (indent.length >= 2) {
+          const newLine = `${indent.slice(2)}- `;
+          const newValue =
+            value.slice(0, lineStart) + newLine + value.slice(lineEnd);
+          applyEdit(textarea, newValue, lineStart + newLine.length);
+        } else {
+          const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
+          applyEdit(textarea, newValue, lineStart + 1);
+        }
+        return;
+      }
+
+      if (e.key === "Tab") {
+        if (!/^\s*- /.test(currentLine)) return;
+
+        e.preventDefault();
+        if (e.shiftKey) {
+          if (!currentLine.startsWith("  ")) return;
+          const newValue =
+            value.slice(0, lineStart) +
+            currentLine.slice(2) +
+            value.slice(lineEnd);
+          applyEdit(
+            textarea,
+            newValue,
+            lineStart + Math.max(0, cursor - lineStart - 2),
+          );
+        } else {
+          const newValue =
+            value.slice(0, lineStart) +
+            "  " +
+            currentLine +
+            value.slice(lineEnd);
+          applyEdit(textarea, newValue, cursor + 2);
+        }
+      }
+    },
+    [applyEdit],
+  );
+
+  return { onKeyDown };
+}

--- a/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
+++ b/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
@@ -2,6 +2,15 @@
 
 import { useCallback, useRef } from "react";
 
+function isInsideCodeBlock(value: string, cursor: number): boolean {
+  const lines = value.slice(0, cursor).split("\n");
+  let fenceCount = 0;
+  for (const line of lines) {
+    if (line.startsWith("```")) fenceCount++;
+  }
+  return fenceCount % 2 === 1;
+}
+
 export function useMarkdownListEditor(
   _content: string,
   setContent: (value: string) => void,
@@ -64,7 +73,10 @@ export function useMarkdownListEditor(
       }
 
       if (e.key === "Tab") {
-        if (!/^\s*- /.test(currentLine)) return;
+        const isListLine = /^\s*- /.test(currentLine);
+        const inCodeBlock = isInsideCodeBlock(value, cursor);
+
+        if (!isListLine && !inCodeBlock) return;
 
         e.preventDefault();
         if (e.shiftKey) {
@@ -78,12 +90,15 @@ export function useMarkdownListEditor(
             newValue,
             lineStart + Math.max(0, cursor - lineStart - 2),
           );
-        } else {
+        } else if (isListLine) {
           const newValue =
             value.slice(0, lineStart) +
             "  " +
             currentLine +
             value.slice(lineEnd);
+          applyEdit(textarea, newValue, cursor + 2);
+        } else {
+          const newValue = value.slice(0, cursor) + "  " + value.slice(cursor);
           applyEdit(textarea, newValue, cursor + 2);
         }
       }

--- a/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
+++ b/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
@@ -11,10 +11,7 @@ function isInsideCodeBlock(value: string, cursor: number): boolean {
   return fenceCount % 2 === 1;
 }
 
-export function useMarkdownListEditor(
-  _content: string,
-  setContent: (value: string) => void,
-) {
+export function useMarkdownListEditor(setContent: (value: string) => void) {
   const pendingCursorRef = useRef<number | null>(null);
 
   const applyEdit = useCallback(
@@ -67,7 +64,7 @@ export function useMarkdownListEditor(
           applyEdit(textarea, newValue, lineStart + newLine.length);
         } else {
           const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
-          applyEdit(textarea, newValue, lineStart + 1);
+          applyEdit(textarea, newValue, Math.min(lineStart, newValue.length));
         }
         return;
       }
@@ -90,15 +87,15 @@ export function useMarkdownListEditor(
             newValue,
             lineStart + Math.max(0, cursor - lineStart - 2),
           );
-        } else if (isListLine) {
+        } else if (inCodeBlock) {
+          const newValue = value.slice(0, cursor) + "  " + value.slice(cursor);
+          applyEdit(textarea, newValue, cursor + 2);
+        } else {
           const newValue =
             value.slice(0, lineStart) +
             "  " +
             currentLine +
             value.slice(lineEnd);
-          applyEdit(textarea, newValue, cursor + 2);
-        } else {
-          const newValue = value.slice(0, cursor) + "  " + value.slice(cursor);
           applyEdit(textarea, newValue, cursor + 2);
         }
       }


### PR DESCRIPTION
## 変更内容

- `-` で始まる行でEnterを押すと次の行も `- ` が自動挿入されるようにした
- `- ` のみの行（空アイテム）でEnterを押すとインデントを一段下げる（インデントなしの場合は `- ` を削除）
- リスト行でTabを押すと行頭に2スペース追加、Shift+Tabで2スペース削除
- コードブロック内でTabを押すとカーソル位置に2スペース挿入、Shift+Tabで行頭から2スペース削除
- ブログ・ポートフォリオの作成・編集ページ（計4ページ）に適用

## 該当するissue

- close #157