### PR TITLE
[Frontend] admin ドキュメントフォームを共通コンポーネントに抽出

### DIFF
--- a/frontend/src/app/admin/blog/create/page.tsx
+++ b/frontend/src/app/admin/blog/create/page.tsx
@@ -4,9 +4,7 @@ import { useRouter } from "next/navigation";
 import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminBlogCreate } from "@/app/hooks/admin/useAdminBlogCreate";
 import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
-import { AdminMarkdownPreview } from "@/app/admin/components/AdminMarkdownPreview";
-import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
-import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
+import { AdminDocForm } from "@/app/admin/components/AdminDocForm";
 
 export default function CreateBlogPage() {
   const router = useRouter();
@@ -34,11 +32,6 @@ export default function CreateBlogPage() {
     state: { tags: availableTags },
   } = useAdminTags({ onUnauthorized: () => router.push("/admin/login") });
 
-  const { previewContent, onCompositionStart, onCompositionEnd } =
-    useCommittedPreview(content);
-
-  const { onKeyDown } = useMarkdownListEditor(setContent);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -56,101 +49,43 @@ export default function CreateBlogPage() {
   };
 
   return (
-    <div className="container mx-auto p-8">
-      <h1 className="mb-6 text-3xl font-bold">ブログ新規作成</h1>
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <form onSubmit={handleSubmit}>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              タイトル
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-            />
+    <AdminDocForm
+      heading="ブログ新規作成"
+      title={title}
+      setTitle={setTitle}
+      date={date}
+      setDate={setDate}
+      description={description}
+      setDescription={setDescription}
+      content={content}
+      setContent={setContent}
+      isDraft={isDraft}
+      setIsDraft={setIsDraft}
+      onSubmit={handleSubmit}
+      isLoading={isLoading}
+      publishLabel="ブログを投稿する"
+      extraFields={
+        <div className="mb-4">
+          <label className="mb-2 block text-sm font-bold text-gray-700">
+            タグ
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {availableTags.map((tag) => (
+              <label
+                key={tag.id}
+                className="flex items-center gap-1 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={tags.includes(tag.name)}
+                  onChange={() => toggleTag(tag.name)}
+                />
+                <span>{tag.name}</span>
+              </label>
+            ))}
           </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              日付
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              説明文
-            </label>
-            <textarea
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              タグ
-            </label>
-            <div className="flex flex-wrap gap-2">
-              {availableTags.map((tag) => (
-                <label
-                  key={tag.id}
-                  className="flex items-center gap-1 cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    checked={tags.includes(tag.name)}
-                    onChange={() => toggleTag(tag.name)}
-                  />
-                  <span>{tag.name}</span>
-                </label>
-              ))}
-            </div>
-          </div>
-          <div className="mb-6">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              内容
-            </label>
-            <textarea
-              className="h-64 w-full rounded border px-3 py-2 shadow focus:outline-none"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              onCompositionStart={onCompositionStart}
-              onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
-              onKeyDown={onKeyDown}
-              required
-            />
-          </div>
-          <div className="mb-6">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={isDraft}
-                onChange={(e) => setIsDraft(e.target.checked)}
-              />
-              <span className="text-sm font-bold text-gray-700">
-                下書きとして保存
-              </span>
-            </label>
-          </div>
-          <button
-            className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700 disabled:opacity-50"
-            type="submit"
-            disabled={isLoading}
-          >
-            {isDraft ? "下書きを保存する" : "ブログを投稿する"}
-          </button>
-        </form>
-        <AdminMarkdownPreview content={previewContent} />
-      </div>
-    </div>
+        </div>
+      }
+    />
   );
 }

--- a/frontend/src/app/admin/blog/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/blog/edit/[slug]/page.tsx
@@ -4,9 +4,7 @@ import { useRouter, useParams } from "next/navigation";
 import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminBlogEdit } from "@/app/hooks/admin/useAdminBlogEdit";
 import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
-import { AdminMarkdownPreview } from "@/app/admin/components/AdminMarkdownPreview";
-import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
-import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
+import { AdminDocForm } from "@/app/admin/components/AdminDocForm";
 
 export default function EditBlogPage() {
   const router = useRouter();
@@ -38,11 +36,6 @@ export default function EditBlogPage() {
     state: { tags: availableTags },
   } = useAdminTags({ onUnauthorized: handleUnauthorized });
 
-  const { previewContent, onCompositionStart, onCompositionEnd } =
-    useCommittedPreview(content);
-
-  const { onKeyDown } = useMarkdownListEditor(setContent);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -60,101 +53,43 @@ export default function EditBlogPage() {
   };
 
   return (
-    <div className="container mx-auto p-8">
-      <h1 className="mb-6 text-3xl font-bold">Edit Blog</h1>
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <form onSubmit={handleSubmit}>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              タイトル
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-            />
+    <AdminDocForm
+      heading="Edit Blog"
+      title={title}
+      setTitle={setTitle}
+      date={date}
+      setDate={setDate}
+      description={description}
+      setDescription={setDescription}
+      content={content}
+      setContent={setContent}
+      isDraft={isDraft}
+      setIsDraft={setIsDraft}
+      onSubmit={handleSubmit}
+      isLoading={isLoading}
+      publishLabel="ブログを更新する"
+      extraFields={
+        <div className="mb-4">
+          <label className="mb-2 block text-sm font-bold text-gray-700">
+            タグ
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {availableTags.map((tag) => (
+              <label
+                key={tag.id}
+                className="flex items-center gap-1 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={tags.includes(tag.name)}
+                  onChange={() => toggleTag(tag.name)}
+                />
+                <span>{tag.name}</span>
+              </label>
+            ))}
           </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              日付
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              説明文
-            </label>
-            <textarea
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              タグ
-            </label>
-            <div className="flex flex-wrap gap-2">
-              {availableTags.map((tag) => (
-                <label
-                  key={tag.id}
-                  className="flex items-center gap-1 cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    checked={tags.includes(tag.name)}
-                    onChange={() => toggleTag(tag.name)}
-                  />
-                  <span>{tag.name}</span>
-                </label>
-              ))}
-            </div>
-          </div>
-          <div className="mb-6">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              本文
-            </label>
-            <textarea
-              className="h-64 w-full rounded border px-3 py-2 shadow focus:outline-none"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              onCompositionStart={onCompositionStart}
-              onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
-              onKeyDown={onKeyDown}
-              required
-            />
-          </div>
-          <div className="mb-6">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={isDraft}
-                onChange={(e) => setIsDraft(e.target.checked)}
-              />
-              <span className="text-sm font-bold text-gray-700">
-                下書きとして保存
-              </span>
-            </label>
-          </div>
-          <button
-            className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700 disabled:opacity-50"
-            type="submit"
-            disabled={isLoading}
-          >
-            {isDraft ? "下書きを保存する" : "ブログを更新する"}
-          </button>
-        </form>
-        <AdminMarkdownPreview content={previewContent} />
-      </div>
-    </div>
+        </div>
+      }
+    />
   );
 }

--- a/frontend/src/app/admin/components/AdminDocForm.tsx
+++ b/frontend/src/app/admin/components/AdminDocForm.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AdminMarkdownPreview } from "./AdminMarkdownPreview";
+import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
+import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
+
+type AdminDocFormProps = {
+  heading: string;
+  title: string;
+  setTitle: (v: string) => void;
+  date: string;
+  setDate: (v: string) => void;
+  description: string;
+  setDescription: (v: string) => void;
+  content: string;
+  setContent: (v: string) => void;
+  isDraft: boolean;
+  setIsDraft: (v: boolean) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  isLoading: boolean;
+  publishLabel: string;
+  extraFields?: ReactNode;
+};
+
+export function AdminDocForm({
+  heading,
+  title,
+  setTitle,
+  date,
+  setDate,
+  description,
+  setDescription,
+  content,
+  setContent,
+  isDraft,
+  setIsDraft,
+  onSubmit,
+  isLoading,
+  publishLabel,
+  extraFields,
+}: AdminDocFormProps) {
+  const { previewContent, onCompositionStart, onCompositionEnd } =
+    useCommittedPreview(content);
+  const { onKeyDown } = useMarkdownListEditor(setContent);
+
+  const buttonLabel = isDraft ? "下書きを保存する" : publishLabel;
+
+  return (
+    <div className="container mx-auto p-8">
+      <h1 className="mb-6 text-3xl font-bold">{heading}</h1>
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <form onSubmit={onSubmit}>
+          <div className="mb-4">
+            <label className="mb-2 block text-sm font-bold text-gray-700">
+              タイトル
+            </label>
+            <input
+              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+            />
+          </div>
+          <div className="mb-4">
+            <label className="mb-2 block text-sm font-bold text-gray-700">
+              日付
+            </label>
+            <input
+              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              required
+            />
+          </div>
+          <div className="mb-4">
+            <label className="mb-2 block text-sm font-bold text-gray-700">
+              説明文
+            </label>
+            <textarea
+              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              required
+            />
+          </div>
+          {extraFields}
+          <div className="mb-6">
+            <label className="mb-2 block text-sm font-bold text-gray-700">
+              内容
+            </label>
+            <textarea
+              className="h-64 w-full rounded border px-3 py-2 shadow focus:outline-none"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              onCompositionStart={onCompositionStart}
+              onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
+              onKeyDown={onKeyDown}
+              required
+            />
+          </div>
+          <div className="mb-6">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={isDraft}
+                onChange={(e) => setIsDraft(e.target.checked)}
+              />
+              <span className="text-sm font-bold text-gray-700">
+                下書きとして保存
+              </span>
+            </label>
+          </div>
+          <button
+            className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700 disabled:opacity-50"
+            type="submit"
+            disabled={isLoading}
+          >
+            {buttonLabel}
+          </button>
+        </form>
+        <AdminMarkdownPreview content={previewContent} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/portfolio/create/page.tsx
+++ b/frontend/src/app/admin/portfolio/create/page.tsx
@@ -3,9 +3,7 @@
 import { useRouter } from "next/navigation";
 import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminPortfolioCreate } from "@/app/hooks/admin/useAdminPortfolioCreate";
-import { AdminMarkdownPreview } from "@/app/admin/components/AdminMarkdownPreview";
-import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
-import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
+import { AdminDocForm } from "@/app/admin/components/AdminDocForm";
 
 export default function CreatePortfolioPage() {
   const router = useRouter();
@@ -29,11 +27,6 @@ export default function CreatePortfolioPage() {
     actions: { submitCreate },
   } = useAdminPortfolioCreate();
 
-  const { previewContent, onCompositionStart, onCompositionEnd } =
-    useCommittedPreview(content);
-
-  const { onKeyDown } = useMarkdownListEditor(setContent);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -51,92 +44,34 @@ export default function CreatePortfolioPage() {
   };
 
   return (
-    <div className="container mx-auto p-8">
-      <h1 className="mb-6 text-3xl font-bold">ポートフォリオ新規作成</h1>
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <form onSubmit={handleSubmit}>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              タイトル
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              日付
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              説明文
-            </label>
-            <textarea
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              画像URL
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="text"
-              value={coverImage}
-              onChange={(e) => setCoverImage(e.target.value)}
-            />
-          </div>
-          <div className="mb-6">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              内容
-            </label>
-            <textarea
-              className="h-64 w-full rounded border px-3 py-2 shadow focus:outline-none"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              onCompositionStart={onCompositionStart}
-              onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
-              onKeyDown={onKeyDown}
-              required
-            />
-          </div>
-          <div className="mb-6">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={isDraft}
-                onChange={(e) => setIsDraft(e.target.checked)}
-              />
-              <span className="text-sm font-bold text-gray-700">
-                下書きとして保存
-              </span>
-            </label>
-          </div>
-          <button
-            className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700 disabled:opacity-50"
-            type="submit"
-            disabled={isLoading}
-          >
-            {isDraft ? "下書きを保存する" : "ポートフォリオを投稿する"}
-          </button>
-        </form>
-        <AdminMarkdownPreview content={previewContent} />
-      </div>
-    </div>
+    <AdminDocForm
+      heading="ポートフォリオ新規作成"
+      title={title}
+      setTitle={setTitle}
+      date={date}
+      setDate={setDate}
+      description={description}
+      setDescription={setDescription}
+      content={content}
+      setContent={setContent}
+      isDraft={isDraft}
+      setIsDraft={setIsDraft}
+      onSubmit={handleSubmit}
+      isLoading={isLoading}
+      publishLabel="ポートフォリオを投稿する"
+      extraFields={
+        <div className="mb-4">
+          <label className="mb-2 block text-sm font-bold text-gray-700">
+            画像URL
+          </label>
+          <input
+            className="w-full rounded border px-3 py-2 shadow focus:outline-none"
+            type="text"
+            value={coverImage}
+            onChange={(e) => setCoverImage(e.target.value)}
+          />
+        </div>
+      }
+    />
   );
 }

--- a/frontend/src/app/admin/portfolio/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/portfolio/edit/[slug]/page.tsx
@@ -3,9 +3,7 @@
 import { useRouter, useParams } from "next/navigation";
 import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminPortfolioEdit } from "@/app/hooks/admin/useAdminPortfolioEdit";
-import { AdminMarkdownPreview } from "@/app/admin/components/AdminMarkdownPreview";
-import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
-import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
+import { AdminDocForm } from "@/app/admin/components/AdminDocForm";
 
 export default function EditPortfolioPage() {
   const router = useRouter();
@@ -33,11 +31,6 @@ export default function EditPortfolioPage() {
     onUnauthorized: () => router.push("/admin/login"),
   });
 
-  const { previewContent, onCompositionStart, onCompositionEnd } =
-    useCommittedPreview(content);
-
-  const { onKeyDown } = useMarkdownListEditor(setContent);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -55,92 +48,34 @@ export default function EditPortfolioPage() {
   };
 
   return (
-    <div className="container mx-auto p-8">
-      <h1 className="mb-6 text-3xl font-bold">ポートフォリオ編集</h1>
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <form onSubmit={handleSubmit}>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              タイトル
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              日付
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              説明文
-            </label>
-            <textarea
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              required
-            />
-          </div>
-          <div className="mb-4">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              画像URL
-            </label>
-            <input
-              className="w-full rounded border px-3 py-2 shadow focus:outline-none"
-              type="text"
-              value={coverImage}
-              onChange={(e) => setCoverImage(e.target.value)}
-            />
-          </div>
-          <div className="mb-6">
-            <label className="mb-2 block text-sm font-bold text-gray-700">
-              内容
-            </label>
-            <textarea
-              className="h-64 w-full rounded border px-3 py-2 shadow focus:outline-none"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              onCompositionStart={onCompositionStart}
-              onCompositionEnd={(e) => onCompositionEnd(e.currentTarget.value)}
-              onKeyDown={onKeyDown}
-              required
-            />
-          </div>
-          <div className="mb-6">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={isDraft}
-                onChange={(e) => setIsDraft(e.target.checked)}
-              />
-              <span className="text-sm font-bold text-gray-700">
-                下書きとして保存
-              </span>
-            </label>
-          </div>
-          <button
-            className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700 disabled:opacity-50"
-            type="submit"
-            disabled={isLoading}
-          >
-            {isDraft ? "下書きを保存する" : "ポートフォリオを更新する"}
-          </button>
-        </form>
-        <AdminMarkdownPreview content={previewContent} />
-      </div>
-    </div>
+    <AdminDocForm
+      heading="ポートフォリオ編集"
+      title={title}
+      setTitle={setTitle}
+      date={date}
+      setDate={setDate}
+      description={description}
+      setDescription={setDescription}
+      content={content}
+      setContent={setContent}
+      isDraft={isDraft}
+      setIsDraft={setIsDraft}
+      onSubmit={handleSubmit}
+      isLoading={isLoading}
+      publishLabel="ポートフォリオを更新する"
+      extraFields={
+        <div className="mb-4">
+          <label className="mb-2 block text-sm font-bold text-gray-700">
+            画像URL
+          </label>
+          <input
+            className="w-full rounded border px-3 py-2 shadow focus:outline-none"
+            type="text"
+            value={coverImage}
+            onChange={(e) => setCoverImage(e.target.value)}
+          />
+        </div>
+      }
+    />
   );
 }


### PR DESCRIPTION
## 変更内容

- ブログ・ポートフォリオの新規作成・編集ページ (4箇所) で重複していたフォーム UI を `AdminDocForm` コンポーネントに抽出
- `useCommittedPreview` / `useMarkdownListEditor` / `AdminMarkdownPreview` を `AdminDocForm` 内部に取り込み、各ページから削除
- ブログ固有のタグフィールド・ポートフォリオ固有の画像 URL フィールドは `extraFields?: ReactNode` スロットで注入する設計とし、`AdminDocForm` がドメイン知識を持たないようにした

## 該当するissue

<!-- もしあれば -->