### PR TITLE
[Frontend] admin本文エリアの自動リサイズとプレビューの独立スクロール対応

### DIFF
--- a/frontend/src/app/admin/components/AdminDocForm.tsx
+++ b/frontend/src/app/admin/components/AdminDocForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { useRef, useEffect } from "react";
 import { AdminMarkdownPreview } from "./AdminMarkdownPreview";
 import { useCommittedPreview } from "@/app/hooks/admin/useCommittedPreview";
 import { useMarkdownListEditor } from "@/app/hooks/admin/useMarkdownListEditor";
@@ -43,6 +44,14 @@ export function AdminDocForm({
   const { previewContent, onCompositionStart, onCompositionEnd } =
     useCommittedPreview(content);
   const { onKeyDown } = useMarkdownListEditor(setContent);
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [content]);
 
   const buttonLabel = isDraft ? "下書きを保存する" : publishLabel;
 
@@ -92,7 +101,8 @@ export function AdminDocForm({
               内容
             </label>
             <textarea
-              className="h-64 w-full rounded border px-3 py-2 shadow focus:outline-none"
+              ref={contentRef}
+              className="min-h-64 w-full overflow-hidden rounded border px-3 py-2 shadow focus:outline-none"
               value={content}
               onChange={(e) => setContent(e.target.value)}
               onCompositionStart={onCompositionStart}

--- a/frontend/src/app/admin/components/AdminMarkdownPreview.tsx
+++ b/frontend/src/app/admin/components/AdminMarkdownPreview.tsx
@@ -14,7 +14,7 @@ export function AdminMarkdownPreview({ content }: AdminMarkdownPreviewProps) {
   return (
     <div>
       <h2 className="mb-4 text-xl font-bold">プレビュー</h2>
-      <aside className="self-start rounded border bg-white p-6 shadow lg:sticky lg:top-8">
+      <aside className="self-start rounded border bg-white p-6 shadow lg:sticky lg:top-8 lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto">
         <div className="prose max-w-none">
           {hasContent ? (
             <MarkdownRenderer content={content} ogpData={ogpData} />


### PR DESCRIPTION
## 変更内容

- 内容テキストエリアの高さを固定（`h-64`）から自動リサイズ（`min-h-64` + `scrollHeight` 追従）に変更
- プレビューパネルにデスクトップ幅での最大高さ（`max-h-[calc(100vh-6rem)]`）と独立スクロール（`overflow-y-auto`）を追加し、ページスクロールと分離

## 該当するissue

- close #158