### PR TITLE
[Frontend] 選択中のナビタブに常時アンダーバーを表示する

### DIFF
--- a/frontend/src/app/components/header.tsx
+++ b/frontend/src/app/components/header.tsx
@@ -2,16 +2,27 @@
 
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { ROUTES } from "@/app/routes";
 
-const animatedUnderline = `
+const baseNavLink = `
   relative
   text-gray-900
   transition-colors duration-200
-  after:absolute after:left-0 after:bottom-0 after:h-[2px] after:w-0 after:bg-current
+  after:absolute after:left-0 after:bottom-0 after:h-[2px] after:bg-current
+`;
+
+const animatedUnderline = `
+  ${baseNavLink}
+  after:w-0
   motion-safe:after:transition-all motion-safe:after:duration-200
   motion-reduce:after:transition-none
   hover:after:w-full focus-visible:after:w-full
+`;
+
+const activeUnderline = `
+  ${baseNavLink}
+  after:w-full
 `;
 
 const navItems = [
@@ -21,8 +32,16 @@ const navItems = [
   { id: "portfolio", link: ROUTES.PORTFOLIO, label: "ポートフォリオ" },
 ];
 
+function isActivePath(pathname: string, link: string): boolean {
+  if (link === ROUTES.HOME) {
+    return pathname === "/";
+  }
+  return pathname.startsWith(link);
+}
+
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
 
   const closeMenu = () => setIsOpen(false);
 
@@ -62,7 +81,7 @@ export default function Header() {
               <li key={item.id}>
                 <Link
                   href={item.link}
-                  className={`no-underline ${animatedUnderline}`}
+                  className={`no-underline ${isActivePath(pathname, item.link) ? activeUnderline : animatedUnderline}`}
                 >
                   {item.label}
                 </Link>

--- a/frontend/src/app/components/header.tsx
+++ b/frontend/src/app/components/header.tsx
@@ -23,6 +23,8 @@ const animatedUnderline = `
 const activeUnderline = `
   ${baseNavLink}
   after:w-full
+  motion-safe:after:transition-all motion-safe:after:duration-200
+  motion-reduce:after:transition-none
 `;
 
 const navItems = [
@@ -32,11 +34,12 @@ const navItems = [
   { id: "portfolio", link: ROUTES.PORTFOLIO, label: "ポートフォリオ" },
 ];
 
-function isActivePath(pathname: string, link: string): boolean {
+function isActivePath(pathname: string | null, link: string): boolean {
+  if (!pathname) return false;
   if (link === ROUTES.HOME) {
     return pathname === "/";
   }
-  return pathname.startsWith(link);
+  return pathname === link || pathname.startsWith(link + "/");
 }
 
 export default function Header() {


### PR DESCRIPTION
## 変更内容

- `usePathname` を使って現在のパスを検出し、アクティブなナビタブを判定する `isActivePath()` 関数を追加
- アクティブなタブには `after:w-full` で常時アンダーバーを表示する `activeUnderline` スタイルを追加
- 非アクティブなタブは従来通りホバー時のアニメーションアンダーバーを維持

## 該当するissue

- close #79