### PR TITLE
[Frontend] Admin エディターにトグル機能を追加

### DIFF
--- a/frontend/src/app/components/MarkdownRenderer.tsx
+++ b/frontend/src/app/components/MarkdownRenderer.tsx
@@ -7,7 +7,7 @@ import type { OgpData } from "@/app/types/ogp";
 import { remarkLinkPreview } from "@/app/utils/remarkLinkPreview";
 import {
   parseToggleSegments,
-  type Segment,
+  type ToggleNode,
 } from "@/app/utils/preprocessToggles";
 import { LinkPreviewCard } from "@/app/components/LinkPreviewCard";
 import { CodeBlock } from "@/app/components/CodeBlock";
@@ -64,7 +64,7 @@ function SegmentRenderer({
   segment,
   ogpData,
 }: {
-  segment: Segment;
+  segment: ToggleNode;
   ogpData: Record<string, OgpData>;
 }) {
   if (segment.type === "toggle") {

--- a/frontend/src/app/components/MarkdownRenderer.tsx
+++ b/frontend/src/app/components/MarkdownRenderer.tsx
@@ -5,6 +5,10 @@ import rehypeHighlight from "rehype-highlight";
 import rehypeRaw from "rehype-raw";
 import type { OgpData } from "@/app/types/ogp";
 import { remarkLinkPreview } from "@/app/utils/remarkLinkPreview";
+import {
+  parseToggleSegments,
+  type Segment,
+} from "@/app/utils/preprocessToggles";
 import { LinkPreviewCard } from "@/app/components/LinkPreviewCard";
 import { CodeBlock } from "@/app/components/CodeBlock";
 
@@ -13,7 +17,13 @@ type Props = {
   ogpData?: Record<string, OgpData>;
 };
 
-export function MarkdownRenderer({ content, ogpData = {} }: Props) {
+function MarkdownContent({
+  content,
+  ogpData,
+}: {
+  content: string;
+  ogpData: Record<string, OgpData>;
+}) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkLinkPreview]}
@@ -47,5 +57,36 @@ export function MarkdownRenderer({ content, ogpData = {} }: Props) {
     >
       {content}
     </ReactMarkdown>
+  );
+}
+
+function SegmentRenderer({
+  segment,
+  ogpData,
+}: {
+  segment: Segment;
+  ogpData: Record<string, OgpData>;
+}) {
+  if (segment.type === "toggle") {
+    return (
+      <details className="toggle">
+        <summary>{segment.title}</summary>
+        {segment.children.map((child, i) => (
+          <SegmentRenderer key={i} segment={child} ogpData={ogpData} />
+        ))}
+      </details>
+    );
+  }
+  return <MarkdownContent content={segment.content} ogpData={ogpData} />;
+}
+
+export function MarkdownRenderer({ content, ogpData = {} }: Props) {
+  const segments = parseToggleSegments(content);
+  return (
+    <>
+      {segments.map((seg, i) => (
+        <SegmentRenderer key={i} segment={seg} ogpData={ogpData} />
+      ))}
+    </>
   );
 }

--- a/frontend/src/app/components/MarkdownRenderer.tsx
+++ b/frontend/src/app/components/MarkdownRenderer.tsx
@@ -83,10 +83,10 @@ function SegmentRenderer({
 export function MarkdownRenderer({ content, ogpData = {} }: Props) {
   const segments = parseToggleSegments(content);
   return (
-    <>
+    <div>
       {segments.map((seg, i) => (
         <SegmentRenderer key={i} segment={seg} ogpData={ogpData} />
       ))}
-    </>
+    </div>
   );
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -49,6 +49,39 @@ pre code:not(.hljs) {
   }
 }
 
+.prose details.toggle {
+  border-left: 2px solid var(--border);
+  padding-left: 1rem;
+  margin: 0.5rem 0;
+}
+
+.prose details.toggle > summary {
+  cursor: pointer;
+  font-weight: 500;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  user-select: none;
+}
+
+.prose details.toggle > summary::before {
+  content: "▶";
+  font-size: 0.65rem;
+  transition: transform 0.15s ease;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.prose details.toggle[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.prose details.toggle > summary::-webkit-details-marker {
+  display: none;
+}
+
 html {
   scrollbar-gutter: stable;
 }

--- a/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
+++ b/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
@@ -51,42 +51,24 @@ export function useMarkdownListEditor(setContent: (value: string) => void) {
 
         e.preventDefault();
 
-        if (listMatch) {
-          const indent = listMatch[1];
-          const itemContent = listMatch[2];
+        const match = listMatch ?? toggleMatch;
+        const prefix = listMatch ? "- " : "> ";
+        const indent = match![1];
+        const itemContent = match![2];
 
-          if (itemContent !== "") {
-            const insertion = `\n${indent}- `;
-            const newValue =
-              value.slice(0, cursor) + insertion + value.slice(cursor);
-            applyEdit(textarea, newValue, cursor + insertion.length);
-          } else if (indent.length >= 2) {
-            const newLine = `${indent.slice(2)}- `;
-            const newValue =
-              value.slice(0, lineStart) + newLine + value.slice(lineEnd);
-            applyEdit(textarea, newValue, lineStart + newLine.length);
-          } else {
-            const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
-            applyEdit(textarea, newValue, Math.min(lineStart, newValue.length));
-          }
-        } else if (toggleMatch) {
-          const indent = toggleMatch[1];
-          const itemContent = toggleMatch[2];
-
-          if (itemContent !== "") {
-            const insertion = `\n${indent}> `;
-            const newValue =
-              value.slice(0, cursor) + insertion + value.slice(cursor);
-            applyEdit(textarea, newValue, cursor + insertion.length);
-          } else if (indent.length >= 2) {
-            const newLine = `${indent.slice(2)}> `;
-            const newValue =
-              value.slice(0, lineStart) + newLine + value.slice(lineEnd);
-            applyEdit(textarea, newValue, lineStart + newLine.length);
-          } else {
-            const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
-            applyEdit(textarea, newValue, Math.min(lineStart, newValue.length));
-          }
+        if (itemContent !== "") {
+          const insertion = `\n${indent}${prefix}`;
+          const newValue =
+            value.slice(0, cursor) + insertion + value.slice(cursor);
+          applyEdit(textarea, newValue, cursor + insertion.length);
+        } else if (indent.length >= 2) {
+          const newLine = `${indent.slice(2)}${prefix}`;
+          const newValue =
+            value.slice(0, lineStart) + newLine + value.slice(lineEnd);
+          applyEdit(textarea, newValue, lineStart + newLine.length);
+        } else {
+          const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
+          applyEdit(textarea, newValue, Math.min(lineStart, newValue.length));
         }
         return;
       }

--- a/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
+++ b/frontend/src/app/hooks/admin/useMarkdownListEditor.ts
@@ -46,31 +46,53 @@ export function useMarkdownListEditor(setContent: (value: string) => void) {
 
       if (e.key === "Enter") {
         const listMatch = currentLine.match(/^(\s*)- (.*)/);
-        if (!listMatch) return;
+        const toggleMatch = currentLine.match(/^(\s*)> (.*)/);
+        if (!listMatch && !toggleMatch) return;
 
         e.preventDefault();
-        const indent = listMatch[1];
-        const itemContent = listMatch[2];
 
-        if (itemContent !== "") {
-          const insertion = `\n${indent}- `;
-          const newValue =
-            value.slice(0, cursor) + insertion + value.slice(cursor);
-          applyEdit(textarea, newValue, cursor + insertion.length);
-        } else if (indent.length >= 2) {
-          const newLine = `${indent.slice(2)}- `;
-          const newValue =
-            value.slice(0, lineStart) + newLine + value.slice(lineEnd);
-          applyEdit(textarea, newValue, lineStart + newLine.length);
-        } else {
-          const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
-          applyEdit(textarea, newValue, Math.min(lineStart, newValue.length));
+        if (listMatch) {
+          const indent = listMatch[1];
+          const itemContent = listMatch[2];
+
+          if (itemContent !== "") {
+            const insertion = `\n${indent}- `;
+            const newValue =
+              value.slice(0, cursor) + insertion + value.slice(cursor);
+            applyEdit(textarea, newValue, cursor + insertion.length);
+          } else if (indent.length >= 2) {
+            const newLine = `${indent.slice(2)}- `;
+            const newValue =
+              value.slice(0, lineStart) + newLine + value.slice(lineEnd);
+            applyEdit(textarea, newValue, lineStart + newLine.length);
+          } else {
+            const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
+            applyEdit(textarea, newValue, Math.min(lineStart, newValue.length));
+          }
+        } else if (toggleMatch) {
+          const indent = toggleMatch[1];
+          const itemContent = toggleMatch[2];
+
+          if (itemContent !== "") {
+            const insertion = `\n${indent}> `;
+            const newValue =
+              value.slice(0, cursor) + insertion + value.slice(cursor);
+            applyEdit(textarea, newValue, cursor + insertion.length);
+          } else if (indent.length >= 2) {
+            const newLine = `${indent.slice(2)}> `;
+            const newValue =
+              value.slice(0, lineStart) + newLine + value.slice(lineEnd);
+            applyEdit(textarea, newValue, lineStart + newLine.length);
+          } else {
+            const newValue = value.slice(0, lineStart) + value.slice(lineEnd);
+            applyEdit(textarea, newValue, Math.min(lineStart, newValue.length));
+          }
         }
         return;
       }
 
       if (e.key === "Tab") {
-        const isListLine = /^\s*- /.test(currentLine);
+        const isListLine = /^\s*[->] /.test(currentLine);
         const inCodeBlock = isInsideCodeBlock(value, cursor);
 
         if (!isListLine && !inCodeBlock) return;

--- a/frontend/src/app/utils/preprocessToggles.ts
+++ b/frontend/src/app/utils/preprocessToggles.ts
@@ -23,7 +23,7 @@ function parseLines(lines: string[], baseIndent: number): ToggleNode[] {
 
   while (i < lines.length) {
     const line = lines[i];
-    const match = line.match(/^(\s*)> (.+)/);
+    const match = line.match(/^(\s*)> (.*)/);
 
     if (match && match[1].length === baseIndent) {
       if (markdownLines.length > 0) {

--- a/frontend/src/app/utils/preprocessToggles.ts
+++ b/frontend/src/app/utils/preprocessToggles.ts
@@ -1,0 +1,72 @@
+export type MarkdownSegment = { type: "markdown"; content: string };
+export type ToggleSegment = {
+  type: "toggle";
+  title: string;
+  children: Segment[];
+};
+export type Segment = MarkdownSegment | ToggleSegment;
+
+function detectBodyIndent(lines: string[], startIndex: number): number {
+  for (let i = startIndex; i < lines.length; i++) {
+    if (lines[i] !== "") {
+      const m = lines[i].match(/^(\s*)/);
+      return m ? m[1].length : 0;
+    }
+  }
+  return -1;
+}
+
+function parseLines(lines: string[], baseIndent: number): Segment[] {
+  const segments: Segment[] = [];
+  let i = 0;
+  let markdownLines: string[] = [];
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const match = line.match(/^(\s*)> (.+)/);
+
+    if (match && match[1].length === baseIndent) {
+      if (markdownLines.length > 0) {
+        segments.push({ type: "markdown", content: markdownLines.join("\n") });
+        markdownLines = [];
+      }
+
+      const title = match[2];
+      i++;
+
+      const bodyIndent = detectBodyIndent(lines, i);
+      const bodyLines: string[] = [];
+
+      if (bodyIndent > baseIndent) {
+        while (i < lines.length) {
+          const bodyLine = lines[i];
+          if (bodyLine === "" || bodyLine.startsWith(" ".repeat(bodyIndent))) {
+            bodyLines.push(bodyLine === "" ? "" : bodyLine.slice(bodyIndent));
+            i++;
+          } else {
+            break;
+          }
+        }
+      }
+
+      segments.push({
+        type: "toggle",
+        title,
+        children: parseLines(bodyLines, 0),
+      });
+    } else {
+      markdownLines.push(line);
+      i++;
+    }
+  }
+
+  if (markdownLines.length > 0) {
+    segments.push({ type: "markdown", content: markdownLines.join("\n") });
+  }
+
+  return segments;
+}
+
+export function parseToggleSegments(markdown: string): Segment[] {
+  return parseLines(markdown.split("\n"), 0);
+}

--- a/frontend/src/app/utils/preprocessToggles.ts
+++ b/frontend/src/app/utils/preprocessToggles.ts
@@ -2,22 +2,22 @@ export type MarkdownSegment = { type: "markdown"; content: string };
 export type ToggleSegment = {
   type: "toggle";
   title: string;
-  children: Segment[];
+  children: ToggleNode[];
 };
-export type Segment = MarkdownSegment | ToggleSegment;
+export type ToggleNode = MarkdownSegment | ToggleSegment;
 
 function detectBodyIndent(lines: string[], startIndex: number): number {
   for (let i = startIndex; i < lines.length; i++) {
     if (lines[i] !== "") {
-      const m = lines[i].match(/^(\s*)/);
-      return m ? m[1].length : 0;
+      const indentMatch = lines[i].match(/^(\s*)/);
+      return indentMatch ? indentMatch[1].length : 0;
     }
   }
   return -1;
 }
 
-function parseLines(lines: string[], baseIndent: number): Segment[] {
-  const segments: Segment[] = [];
+function parseLines(lines: string[], baseIndent: number): ToggleNode[] {
+  const segments: ToggleNode[] = [];
   let i = 0;
   let markdownLines: string[] = [];
 
@@ -67,6 +67,6 @@ function parseLines(lines: string[], baseIndent: number): Segment[] {
   return segments;
 }
 
-export function parseToggleSegments(markdown: string): Segment[] {
+export function parseToggleSegments(markdown: string): ToggleNode[] {
   return parseLines(markdown.split("\n"), 0);
 }


### PR DESCRIPTION
## 変更内容

- `> text` 構文でトグル（折り畳みブロック）を作成できるようにした
- `-` リストと同様に Tab でインデント、Shift+Tab でデインデント可能
- インデントベースのネスト構造をサポート（2〜4スペース両対応）
- トグルのボディ内でリスト・ネストトグルなど通常の Markdown が使用可能
- `<details>`/`<summary>` ネイティブ要素で実装（デフォルト閉じた状態）

## 技術的な変更

- `preprocessToggles.ts`: トグル構文を `Segment` ツリーに変換するパーサーを新規作成
- `MarkdownRenderer.tsx`: コンテンツをセグメント単位で個別に ReactMarkdown でレンダリングする方式に変更（HTML ブロック内での Markdown 再パース問題を解消）
- `useMarkdownListEditor.ts`: `> ` 行の Enter/Tab キーハンドリングを追加
- `globals.css`: toggle スタイル（▶ アイコン、開閉アニメーション）を追加

## スクショ
### Input
```
> タイトル
  - なんとか
  - かんとか
  
  | テスト | テスト |
  | :---: | :---|
  | ほげほげ | ふげふげ |
  | へげへげ | ひげひげ |

  なんとか
  > かんとか
    > なんとかかんとか
      - あいうえお4
```

### Output
<img width="500" alt="image" src="https://github.com/user-attachments/assets/57abcae3-9298-4bc7-8469-ef19c2183494" />

## 該当するissue

- close #166