### PR TITLE
[Frontend] セクションボーダーを濃くし、自己紹介タイトルを削除

### DIFF
--- a/frontend/src/app/components/LinkPreviewCard.tsx
+++ b/frontend/src/app/components/LinkPreviewCard.tsx
@@ -18,7 +18,7 @@ export function LinkPreviewCard({ data }: Props) {
       href={data.url}
       target="_blank"
       rel="noopener noreferrer"
-      className="not-prose my-4 flex overflow-hidden rounded-lg border border-gray-200 no-underline transition-colors hover:bg-gray-50"
+      className="not-prose my-4 flex overflow-hidden rounded-lg border border-gray-300 no-underline transition-colors hover:bg-gray-50"
     >
       {data.image && (
         <div className="hidden flex-shrink-0 sm:block sm:w-48">

--- a/frontend/src/app/components/header.tsx
+++ b/frontend/src/app/components/header.tsx
@@ -70,7 +70,7 @@ export default function Header() {
   }, [isOpen]);
 
   return (
-    <header className="sticky top-0 w-full border-b border-gray-200 bg-gray-200 font-sans z-30">
+    <header className="sticky top-0 w-full border-b border-gray-300 bg-gray-200 font-sans z-30">
       <div className="max-w-4xl w-full mx-auto px-4 py-4 flex items-center justify-between">
         <Link
           href={ROUTES.HOME}

--- a/frontend/src/app/ui/blog/page.tsx
+++ b/frontend/src/app/ui/blog/page.tsx
@@ -26,7 +26,7 @@ export default async function BlogPage() {
               <TextSearchSection />
             </section>
 
-            <section className="border-b border-gray-200 pb-8 mb-8">
+            <section className="border-b border-gray-300 pb-8 mb-8">
               <TagSearchSection />
             </section>
 

--- a/frontend/src/app/ui/portfolio/section/PortfolioListSection.tsx
+++ b/frontend/src/app/ui/portfolio/section/PortfolioListSection.tsx
@@ -21,7 +21,7 @@ export default function PortfolioListSection({
             key={portfolio.slug}
             className="block group"
           >
-            <div className="bg-white border border-gray-200 rounded-lg shadow-sm flex flex-col md:flex-row items-stretch gap-0 transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-0.5">
+            <div className="bg-white border border-gray-300 rounded-lg shadow-sm flex flex-col md:flex-row items-stretch gap-0 transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-0.5">
               {portfolio.coverImage && (
                 <div className="relative md:w-1/3 w-full h-48 md:h-auto">
                   <Image

--- a/frontend/src/app/ui/profile/page.tsx
+++ b/frontend/src/app/ui/profile/page.tsx
@@ -14,11 +14,11 @@ export default function AboutPage() {
             プロフィール
           </h1>
 
-          <section className="border-b border-gray-200 pb-12 mb-12">
+          <section className="border-b border-gray-300 pb-12 mb-12">
             <ProfileDetailSection />
           </section>
 
-          <section className="border-b border-gray-200 pb-12 mb-12">
+          <section className="border-b border-gray-300 pb-12 mb-12">
             <CareerSection />
           </section>
 

--- a/frontend/src/app/ui/profile/section/CareerItem.tsx
+++ b/frontend/src/app/ui/profile/section/CareerItem.tsx
@@ -29,7 +29,7 @@ export default function CareerItem({
   return (
     <div
       ref={itemRef}
-      className={`mb-10 ml-4 pl-1 border-l-2 rounded-l-xl ${isOpen ? "border-gray-300" : "border-gray-200"}`}
+      className={`mb-10 ml-4 pl-1 border-l-2 rounded-l-xl ${isOpen ? "border-gray-300" : "border-gray-300"}`}
     >
       <button
         onClick={() =>

--- a/frontend/src/app/ui/profile/section/CareerSection.tsx
+++ b/frontend/src/app/ui/profile/section/CareerSection.tsx
@@ -7,7 +7,7 @@ export default function CareerSection() {
   return (
     <div>
       <h2 className="text-3xl font-bold mb-10 text-gray-900">経歴</h2>
-      <div className="m-6 relative border-l-2 border-gray-200">
+      <div className="m-6 relative border-l-2 border-gray-300">
         {processedCareerData.map((career, index) => (
           <CareerItem key={index} {...career} />
         ))}

--- a/frontend/src/app/ui/top/page.tsx
+++ b/frontend/src/app/ui/top/page.tsx
@@ -12,15 +12,15 @@ export default async function Home() {
       <Header />
       <main id="main-content" className="max-w-4xl mx-auto px-4 py-12">
         <div className="bg-white rounded-lg shadow-sm p-8">
-          <section className="border-b border-gray-200 mt-12 pb-12 text-center">
+          <section className="border-b border-gray-300 mt-12 pb-12 text-center">
             <WelcomeSection />
           </section>
 
-          <section className="border-b border-gray-200 mt-16 pb-16">
+          <section className="border-b border-gray-300 mt-16 pb-16">
             <ProfileSection />
           </section>
 
-          <section className="border-b border-gray-200 mt-16 pb-16">
+          <section className="border-b border-gray-300 mt-16 pb-16">
             <BlogListSection blogs={blogs} />
           </section>
 

--- a/frontend/src/app/ui/top/section/ProfileSection.tsx
+++ b/frontend/src/app/ui/top/section/ProfileSection.tsx
@@ -5,10 +5,9 @@ import { ROUTES, EXTERNAL_LINKS } from "@/app/routes";
 export default function ProfileSection() {
   return (
     <div>
-      <h3 className="text-3xl font-bold mb-12 text-gray-900">自己紹介</h3>
       <div className="flex flex-col gap-8 sm:flex-row sm:items-center">
         <Image
-          className="rounded-full object-cover flex-shrink-0 border-2 border-gray-300"
+          className="rounded-full object-cover shrink-0 border-2 border-gray-300"
           src="/profile.jpg"
           alt="プロフィール画像"
           width={160}


### PR DESCRIPTION
## 変更内容

- サイト全体のセクションボーダーカラーを `border-gray-200` から `border-gray-300` に統一してやや濃くした
- トップページのプロフィールセクションから「自己紹介」見出し (`h3`) を削除

## 該当するissue

- close #172