### PR TITLE
[Frontend] セッション切れ時にブログ入力内容を復元する

### DIFF
--- a/frontend/src/app/admin/blog/create/page.tsx
+++ b/frontend/src/app/admin/blog/create/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminBlogCreate } from "@/app/hooks/admin/useAdminBlogCreate";
 import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
 import { AdminDocForm } from "@/app/admin/components/AdminDocForm";
+import { saveBlogRestore } from "@/app/utils/adminBlogRestore";
 
 export default function CreateBlogPage() {
   const router = useRouter();
+  const pathname = usePathname();
 
   const {
     form: {
@@ -24,7 +26,7 @@ export default function CreateBlogPage() {
       isDraft,
       setIsDraft,
     },
-    state: { isLoading },
+    state: { isLoading, restoreMessage },
     actions: { submitCreate },
   } = useAdminBlogCreate();
 
@@ -40,7 +42,20 @@ export default function CreateBlogPage() {
       router.push("/admin");
     } catch (error) {
       if (error instanceof UnauthorizedError) {
-        router.push("/admin/login");
+        saveBlogRestore({
+          kind: "blog:create",
+          redirectPath: pathname,
+          savedAt: Date.now(),
+          payload: {
+            title,
+            description,
+            content,
+            tags,
+            date,
+            isDraft,
+          },
+        });
+        router.push(`/admin/login?redirect=${encodeURIComponent(pathname)}`);
       } else {
         alert("Failed to create blog");
       }
@@ -64,6 +79,7 @@ export default function CreateBlogPage() {
       onSubmit={handleSubmit}
       isLoading={isLoading}
       publishLabel="ブログを投稿する"
+      restoreMessage={restoreMessage}
       extraFields={
         <div className="mb-4">
           <label className="mb-2 block text-sm font-bold text-gray-700">

--- a/frontend/src/app/admin/blog/edit/[slug]/page.tsx
+++ b/frontend/src/app/admin/blog/edit/[slug]/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useRouter, useParams } from "next/navigation";
+import { usePathname, useRouter, useParams } from "next/navigation";
 import { UnauthorizedError } from "@/app/types/errors";
 import { useAdminBlogEdit } from "@/app/hooks/admin/useAdminBlogEdit";
 import { useAdminTags } from "@/app/hooks/admin/useAdminTags";
 import { AdminDocForm } from "@/app/admin/components/AdminDocForm";
+import { saveBlogRestore } from "@/app/utils/adminBlogRestore";
 
 export default function EditBlogPage() {
   const router = useRouter();
+  const pathname = usePathname();
   const params = useParams();
   const originalSlug = params.slug as string;
 
@@ -28,7 +30,7 @@ export default function EditBlogPage() {
       isDraft,
       setIsDraft,
     },
-    state: { isLoading },
+    state: { isLoading, restoreMessage },
     actions: { submitUpdate },
   } = useAdminBlogEdit(originalSlug, { onUnauthorized: handleUnauthorized });
 
@@ -44,7 +46,21 @@ export default function EditBlogPage() {
       router.push("/admin");
     } catch (error) {
       if (error instanceof UnauthorizedError) {
-        router.push("/admin/login");
+        saveBlogRestore({
+          kind: "blog:edit",
+          slug: originalSlug,
+          redirectPath: pathname,
+          savedAt: Date.now(),
+          payload: {
+            title,
+            description,
+            content,
+            tags,
+            date,
+            isDraft,
+          },
+        });
+        router.push(`/admin/login?redirect=${encodeURIComponent(pathname)}`);
       } else {
         alert("Failed to update blog");
       }
@@ -68,6 +84,7 @@ export default function EditBlogPage() {
       onSubmit={handleSubmit}
       isLoading={isLoading}
       publishLabel="ブログを更新する"
+      restoreMessage={restoreMessage}
       extraFields={
         <div className="mb-4">
           <label className="mb-2 block text-sm font-bold text-gray-700">

--- a/frontend/src/app/admin/components/AdminDocForm.tsx
+++ b/frontend/src/app/admin/components/AdminDocForm.tsx
@@ -21,6 +21,7 @@ type AdminDocFormProps = {
   onSubmit: (e: React.FormEvent) => void;
   isLoading: boolean;
   publishLabel: string;
+  restoreMessage?: string;
   extraFields?: ReactNode;
 };
 
@@ -39,6 +40,7 @@ export function AdminDocForm({
   onSubmit,
   isLoading,
   publishLabel,
+  restoreMessage,
   extraFields,
 }: AdminDocFormProps) {
   const { previewContent, onCompositionStart, onCompositionEnd } =
@@ -58,6 +60,11 @@ export function AdminDocForm({
   return (
     <div className="container mx-auto p-8">
       <h1 className="mb-6 text-3xl font-bold">{heading}</h1>
+      {restoreMessage && (
+        <p className="mb-4 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+          {restoreMessage}
+        </p>
+      )}
       <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <form onSubmit={onSubmit}>
           <div className="mb-4">

--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAdminLogin } from "@/app/hooks/admin/useAdminLogin";
+import { getSafeAdminRedirect } from "@/app/utils/adminBlogRestore";
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const {
     form: { username, setUsername, password, setPassword },
@@ -18,7 +21,7 @@ export default function LoginPage() {
 
     try {
       await submit();
-      router.push("/admin");
+      router.push(getSafeAdminRedirect(searchParams.get("redirect")));
     } catch (error) {
       // error message is already set in hook
       console.error("Login error:", error);
@@ -75,5 +78,13 @@ export default function LoginPage() {
         </form>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/frontend/src/app/hooks/admin/useAdminBlogCreate.ts
+++ b/frontend/src/app/hooks/admin/useAdminBlogCreate.ts
@@ -1,10 +1,18 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { BlogUpsertInput } from "@/app/types/blog";
 import { adminBlogRepository } from "@/app/repository/adminBlogRepository";
 import {
   getTodayInputDate,
   toJaLongDateFromInput,
 } from "@/app/hooks/admin/adminDate";
+import {
+  type AdminBlogRestorePayload,
+  clearBlogRestore,
+  isFreshBlogRestore,
+  readBlogRestore,
+} from "@/app/utils/adminBlogRestore";
+
+const RESTORE_MESSAGE = "セッション切れ前の入力内容を復元しました";
 
 export function useAdminBlogCreate() {
   const [title, setTitle] = useState("");
@@ -16,6 +24,32 @@ export function useAdminBlogCreate() {
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>("");
+  const [restoreMessage, setRestoreMessage] = useState("");
+
+  const applyRestore = useCallback((payload: AdminBlogRestorePayload) => {
+    setTitle(payload.title);
+    setDescription(payload.description);
+    setContent(payload.content);
+    setTags(payload.tags);
+    setDate(payload.date);
+    setIsDraft(payload.isDraft);
+    setRestoreMessage(RESTORE_MESSAGE);
+  }, []);
+
+  useEffect(() => {
+    const restore = readBlogRestore();
+    if (!restore) return;
+
+    if (!isFreshBlogRestore(restore)) {
+      clearBlogRestore();
+      return;
+    }
+
+    if (restore.kind !== "blog:create") return;
+
+    applyRestore(restore.payload);
+    clearBlogRestore();
+  }, [applyRestore]);
 
   const toggleTag = useCallback((tag: string) => {
     setTags((prev) =>
@@ -61,7 +95,7 @@ export function useAdminBlogCreate() {
       isDraft,
       setIsDraft,
     },
-    state: { isLoading, error },
+    state: { isLoading, error, restoreMessage },
     actions: { submitCreate },
   };
 }

--- a/frontend/src/app/hooks/admin/useAdminBlogEdit.ts
+++ b/frontend/src/app/hooks/admin/useAdminBlogEdit.ts
@@ -6,6 +6,33 @@ import {
   toInputDateStringFromJaDate,
   toJaLongDateFromInput,
 } from "@/app/hooks/admin/adminDate";
+import {
+  clearBlogRestore,
+  isFreshBlogRestore,
+  readBlogRestore,
+} from "@/app/utils/adminBlogRestore";
+
+const RESTORE_MESSAGE = "セッション切れ前の入力内容を復元しました";
+
+type BlogFormValues = {
+  title: string;
+  description: string;
+  content: string;
+  tags: string[];
+  date: string;
+  isDraft: boolean;
+};
+
+function toFormValues(data: Blog): BlogFormValues {
+  return {
+    title: data.title,
+    description: data.description,
+    content: data.content,
+    tags: data.tags || [],
+    date: toInputDateStringFromJaDate(data.date),
+    isDraft: data.isDraft ?? false,
+  };
+}
 
 export function useAdminBlogEdit(
   originalSlug: string | undefined,
@@ -20,6 +47,16 @@ export function useAdminBlogEdit(
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>("");
+  const [restoreMessage, setRestoreMessage] = useState("");
+
+  const applyFormValues = useCallback((values: BlogFormValues) => {
+    setTitle(values.title);
+    setDescription(values.description);
+    setContent(values.content);
+    setTags(values.tags);
+    setDate(values.date);
+    setIsDraft(values.isDraft);
+  }, []);
 
   const onUnauthorizedRef = useRef(onUnauthorized);
   useEffect(() => {
@@ -30,18 +67,24 @@ export function useAdminBlogEdit(
     if (!originalSlug) return;
 
     let cancelled = false;
+
+    const restore = readBlogRestore();
+    if (restore && !isFreshBlogRestore(restore)) {
+      clearBlogRestore();
+    } else if (restore?.kind === "blog:edit" && restore.slug === originalSlug) {
+      applyFormValues(restore.payload);
+      setRestoreMessage(RESTORE_MESSAGE);
+      clearBlogRestore();
+      return;
+    }
+
     const fetchBlog = async () => {
       setIsLoading(true);
       setError("");
       try {
         const data: Blog = await adminBlogRepository.get(originalSlug);
         if (cancelled) return;
-        setTitle(data.title);
-        setDescription(data.description);
-        setContent(data.content);
-        setTags(data.tags || []);
-        setDate(toInputDateStringFromJaDate(data.date));
-        setIsDraft(data.isDraft ?? false);
+        applyFormValues(toFormValues(data));
       } catch (e) {
         if (cancelled) return;
         if (e instanceof UnauthorizedError) {
@@ -60,7 +103,7 @@ export function useAdminBlogEdit(
     return () => {
       cancelled = true;
     };
-  }, [originalSlug]);
+  }, [originalSlug, applyFormValues]);
 
   const toggleTag = useCallback((tag: string) => {
     setTags((prev) =>
@@ -110,7 +153,7 @@ export function useAdminBlogEdit(
       isDraft,
       setIsDraft,
     },
-    state: { isLoading, error },
+    state: { isLoading, error, restoreMessage },
     actions: { submitUpdate },
   };
 }

--- a/frontend/src/app/utils/adminBlogRestore.ts
+++ b/frontend/src/app/utils/adminBlogRestore.ts
@@ -1,0 +1,60 @@
+export type AdminBlogRestorePayload = {
+  title: string;
+  description: string;
+  content: string;
+  tags: string[];
+  date: string;
+  isDraft: boolean;
+};
+
+export type AdminBlogRestoreData = {
+  kind: "blog:create" | "blog:edit";
+  slug?: string;
+  redirectPath: string;
+  savedAt: number;
+  payload: AdminBlogRestorePayload;
+};
+
+const BLOG_RESTORE_KEY = "admin:blog:restore";
+const BLOG_RESTORE_MAX_AGE_MS = 2 * 60 * 60 * 1000;
+
+function canUseSessionStorage() {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.sessionStorage !== "undefined"
+  );
+}
+
+export function saveBlogRestore(data: AdminBlogRestoreData) {
+  if (!canUseSessionStorage()) return;
+  window.sessionStorage.setItem(BLOG_RESTORE_KEY, JSON.stringify(data));
+}
+
+export function readBlogRestore(): AdminBlogRestoreData | null {
+  if (!canUseSessionStorage()) return null;
+
+  const raw = window.sessionStorage.getItem(BLOG_RESTORE_KEY);
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as AdminBlogRestoreData;
+  } catch {
+    clearBlogRestore();
+    return null;
+  }
+}
+
+export function clearBlogRestore() {
+  if (!canUseSessionStorage()) return;
+  window.sessionStorage.removeItem(BLOG_RESTORE_KEY);
+}
+
+export function isFreshBlogRestore(data: AdminBlogRestoreData) {
+  return Date.now() - data.savedAt <= BLOG_RESTORE_MAX_AGE_MS;
+}
+
+export function getSafeAdminRedirect(value: string | null) {
+  if (!value?.startsWith("/admin")) return "/admin";
+  if (value.startsWith("//")) return "/admin";
+  return value;
+}


### PR DESCRIPTION
## 変更内容
- ブログ作成・編集の保存時に認証切れになった場合、入力内容を sessionStorage に退避
- ログイン後に元の作成・編集画面へ戻し、退避した入力内容を復元
- 不正な redirect を /admin にフォールバックするように制御

## 該当するissue

- close #178