### PR TITLE
[Frontend] キャリア詳細のURLを自動リンク化

### DIFF
--- a/frontend/src/app/data/careerData.ts
+++ b/frontend/src/app/data/careerData.ts
@@ -32,6 +32,10 @@ export const careerData: Career[] = [
           "PlantUMLを使用して設計書を作成し、Claude Codeを用いた半自動化した開発スタイルの検証",
         ],
       },
+      {
+        content: "インターンシップ参加にあたり記事も執筆しました",
+        details: ["https://developers.cyberagent.co.jp/blog/archives/63964/"],
+      },
     ],
     technologies: ["Kotlin", "Kotlin Multiplatform", "PlantUML"],
   },

--- a/frontend/src/app/ui/profile/section/CareerItem.tsx
+++ b/frontend/src/app/ui/profile/section/CareerItem.tsx
@@ -74,7 +74,19 @@ export default function CareerItem({
                   <ul className="list-[circle] list-outside pl-5 mt-1 text-gray-700">
                     {task.details.map((sub, subIndex) => (
                       <li key={subIndex} className="mt-2 pl-1">
-                        {sub}
+                        {sub.startsWith("https://") ||
+                        sub.startsWith("http://") ? (
+                          <a
+                            href={sub}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:underline break-all"
+                          >
+                            {sub}
+                          </a>
+                        ) : (
+                          sub
+                        )}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## 変更内容
- キャリア詳細（`details`）の文字列が `http://` または `https://` で始まる場合、自動的に `<a>` タグとしてレンダリングするよう `CareerItem.tsx` を修正
- サイバーエージェントのインターン記事URLを `careerData.ts` に追加

## 該当するissue

<!-- もしあれば -->